### PR TITLE
fix build freeze in dotnet-sdk($ProjectDir is not defined)

### DIFF
--- a/src/ZString/ZString.csproj
+++ b/src/ZString/ZString.csproj
@@ -124,10 +124,10 @@
 
     <!-- Copy files for Unity -->
     <PropertyGroup>
-        <DestinationRoot>$(ProjectDir)..\ZString.Unity\Assets\Scripts\ZString\</DestinationRoot>
+        <DestinationRoot>$(MSBuildProjectDirectory)\..\ZString.Unity\Assets\Scripts\ZString\</DestinationRoot>
     </PropertyGroup>
     <ItemGroup>
-        <TargetFiles1 Include="$(ProjectDir)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />
+        <TargetFiles1 Include="$(MSBuildProjectDirectory)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />
     </ItemGroup>
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
         <Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />


### PR DESCRIPTION
because `$(ProjectDir)` is not defined in `dotnet build`, `dotnet build` attempts to read all files in disk when evaluating following line.
https://github.com/Cysharp/ZString/blob/afbd44ad178c625acaa5bcfe4a0f2e5872204973/src/ZString/ZString.csproj#L130
This behavior causes to spend very long time for building.
So using [MSBuildProjectDirectory](https://docs.microsoft.com/en-us/visualstudio/msbuild/msbuild-reserved-and-well-known-properties?view=vs-2019) instead.