### PR TITLE
Add ZString.Join<T>(char, XxxCollection) overloads

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
@@ -56,6 +56,29 @@ namespace Cysharp.Text
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
+        public static string Join<T>(char separator, List<T> values)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                var count = values.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    if (i != 0)
+                    {
+                        sb.Append(separator);
+                    }
+                    sb.Append(values[i]);
+                }
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+
+        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, ReadOnlySpan<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -103,6 +126,26 @@ namespace Cysharp.Text
             {
                 sb.Dispose();
             }
+        }
+
+        public static string Join<T>(char separator, ICollection<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
+        }
+
+        public static string Join<T>(char separator, IList<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
+        }
+
+        public static string Join<T>(char separator, IReadOnlyList<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
+        }
+
+        public static string Join<T>(char separator, IReadOnlyCollection<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>

--- a/src/ZString/ZString.cs
+++ b/src/ZString/ZString.cs
@@ -56,6 +56,29 @@ namespace Cysharp.Text
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
+        public static string Join<T>(char separator, List<T> values)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                var count = values.Count;
+                for (int i = 0; i < count; i++)
+                {
+                    if (i != 0)
+                    {
+                        sb.Append(separator);
+                    }
+                    sb.Append(values[i]);
+                }
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+
+        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, ReadOnlySpan<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -103,6 +126,26 @@ namespace Cysharp.Text
             {
                 sb.Dispose();
             }
+        }
+
+        public static string Join<T>(char separator, ICollection<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
+        }
+
+        public static string Join<T>(char separator, IList<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
+        }
+
+        public static string Join<T>(char separator, IReadOnlyList<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
+        }
+
+        public static string Join<T>(char separator, IReadOnlyCollection<T> values)
+        {
+            return Join(separator, values.AsEnumerable());
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>

--- a/tests/ZString.Tests/JoinTest.cs
+++ b/tests/ZString.Tests/JoinTest.cs
@@ -64,6 +64,35 @@ namespace ZStringTests
         }
 
         [Fact]
+        public void JoinOverloads3()
+        {
+            ZString.Join(',', new string[] { }.ToList()).Should().Be(string.Join(',', new string[0]));
+            ZString.Join(',', new[] { 1 }.ToList()).Should().Be(string.Join(',', new[] { 1 }));
+            ZString.Join(',', new[] { 1, 2 }.ToList()).Should().Be(string.Join(',', new[] { 1, 2 }));
+            ZString.Join(',', new[] { 1, 2, 3 }.ToList()).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+
+            ZString.Join(',', (IList<int>)new int[] { }).Should().Be(string.Join(',', new string[0]));
+            ZString.Join(',', (IList<int>)new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
+            ZString.Join(',', (IList<int>)new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
+            ZString.Join(',', (IList<int>)new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+
+            ZString.Join(',', (IReadOnlyList<int>)new int[] { }).Should().Be(string.Join(',', new string[0]));
+            ZString.Join(',', (IReadOnlyList<int>)new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
+            ZString.Join(',', (IReadOnlyList<int>)new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
+            ZString.Join(',', (IReadOnlyList<int>)new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+
+            ZString.Join(',', (ICollection<int>)new int[] { }).Should().Be(string.Join(',', new string[0]));
+            ZString.Join(',', (ICollection<int>)new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
+            ZString.Join(',', (ICollection<int>)new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
+            ZString.Join(',', (ICollection<int>)new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+
+            ZString.Join(',', (IReadOnlyCollection<int>)new int[] { }).Should().Be(string.Join(',', new string[0]));
+            ZString.Join(',', (IReadOnlyCollection<int>)new[] { 1 }).Should().Be(string.Join(',', new[] { 1 }));
+            ZString.Join(',', (IReadOnlyCollection<int>)new[] { 1, 2 }).Should().Be(string.Join(',', new[] { 1, 2 }));
+            ZString.Join(',', (IReadOnlyCollection<int>)new[] { 1, 2, 3 }).Should().Be(string.Join(',', new[] { 1, 2, 3 }));
+        }
+
+        [Fact]
         public void CooncatNullTest()
         {
             var str = ZString.Concat(default(string), "foo", "bar");


### PR DESCRIPTION
`ZString.Join<T>` method has many overloads by the `string` separator, but it doesn't provide some overloads by the `char` separator as well. Therefore, this PR adds some `char` separator overloads.