### PR TITLE
Improved performance of ZString.Join

### DIFF
--- a/sandbox/PerfBenchmark/Benchmarks/StringListJoinBenchmark.cs
+++ b/sandbox/PerfBenchmark/Benchmarks/StringListJoinBenchmark.cs
@@ -1,0 +1,100 @@
+﻿using BenchmarkDotNet.Attributes;
+using Cysharp.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+namespace PerfBenchmark.Benchmarks
+{
+    [Config(typeof(BenchmarkConfig))]
+    public class StringListJoinBenchmark
+    {
+        //private const char Separator = ',';
+        private const string Separator = ",";
+
+        List<string> _emptyList;
+        IEnumerable<string> _enum1;
+        string[] _array1;
+        List<string> _list1;
+        IEnumerable<string> _enum2;
+        string[] _array2;
+        List<string> _list2;
+        IEnumerable<string> _enum10;
+        List<string> _list10;
+        string[] _array10;
+
+        public StringListJoinBenchmark()
+        {
+            _emptyList = new List<string>();
+            _enum1 = Enumerable.Repeat(Guid.NewGuid().ToString(), 1);
+            _list1 = _enum1.ToList();
+            _array1 = _enum1.ToArray();
+            _enum2 = Enumerable.Repeat(Guid.NewGuid().ToString(), 2);
+            _list2 = _enum2.ToList();
+            _array2 = _enum2.ToArray();
+            _enum10 = Enumerable.Repeat(Guid.NewGuid().ToString(), 10);
+            _list10 = _enum10.ToList();
+            _array10 = _enum10.ToArray();
+        }
+
+        [Benchmark]
+        public string JoinEmptyList() => String.Join(Separator, _emptyList);
+
+        [Benchmark]
+        public string ZJoinEmptyList() => ZString.Join(Separator, _emptyList);
+
+        [Benchmark]
+        public string JoinList1() => String.Join(Separator, _list1);
+
+        [Benchmark]
+        public string ZJoinList1() => ZString.Join(Separator, _list1);
+
+        [Benchmark]
+        public string JoinArray1() => String.Join(Separator, _array1);
+
+        [Benchmark]
+        public string ZJoinArray1() => ZString.Join(Separator, _array1);
+
+        [Benchmark]
+        public string JoinEnumerable1() => String.Join(Separator, _enum1);
+
+        [Benchmark]
+        public string ZJoinEnumerable1() => ZString.Join(Separator, _enum1);
+
+        [Benchmark]
+        public string JoinList2() => String.Join(Separator, _list2);
+
+        [Benchmark]
+        public string ZJoinList2() => ZString.Join(Separator, _list2);
+
+        [Benchmark]
+        public string JoinArray2() => String.Join(Separator, _array2);
+
+        [Benchmark]
+        public string ZJoinArray2() => ZString.Join(Separator, _array2);
+
+        [Benchmark]
+        public string JoinEnumerable2() => String.Join(Separator, _enum2);
+
+        [Benchmark]
+        public string ZJoinEnumerable2() => ZString.Join(Separator, _enum2);
+
+        [Benchmark]
+        public string JoinList10() => String.Join(Separator, _list10);
+
+        [Benchmark]
+        public string ZJoinList10() => ZString.Join(Separator, _list10);
+
+        [Benchmark]
+        public string JoinArray10() => String.Join(Separator, _array10);
+
+        [Benchmark]
+        public string ZJoinArray10() => ZString.Join(Separator, _array10);
+
+        [Benchmark]
+        public string JoinEnumerable10() => String.Join(Separator, _enum10);
+
+        [Benchmark]
+        public string ZJoinEnumerable10() => ZString.Join(Separator, _enum10);
+
+    }
+}

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -158,12 +158,19 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(string value)
         {
+            Append(value.AsSpan());
+        }
+
+        /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(ReadOnlySpan<char> value)
+        {
             if (buffer.Length - index < value.Length)
             {
                 Grow(value.Length);
             }
 
-            value.CopyTo(0, buffer, index, value.Length);
+            value.CopyTo(buffer.AsSpan(index));
             index += value.Length;
         }
 

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
@@ -37,139 +37,27 @@ namespace Cysharp.Text
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, params T[] values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            return Join(separator, (IList<T>)values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, List<T> values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                var count = values.Count;
-                for (int i = 0; i < count; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            return Join(separator, (IList<T>)values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, ReadOnlySpan<T> values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            Span<char> s = stackalloc char[1] { separator };
+            return JoinInternal(s, values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, IEnumerable<T> values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                var isFirst = true;
-                foreach (var item in values)
-                {
-                    if (!isFirst)
-                    {
-                        sb.Append(separator);
-                    }
-                    else
-                    {
-                        isFirst = false;
-                    }
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            Span<char> s = stackalloc char[1] { separator };
+            return JoinInternal(s, values);
         }
 
         public static string Join<T>(char separator, ICollection<T> values)
@@ -179,7 +67,8 @@ namespace Cysharp.Text
 
         public static string Join<T>(char separator, IList<T> values)
         {
-            return Join(separator, values.AsEnumerable());
+            Span<char> s = stackalloc char[1] { separator };
+            return JoinInternal(s, values);
         }
 
         public static string Join<T>(char separator, IReadOnlyList<T> values)
@@ -195,38 +84,48 @@ namespace Cysharp.Text
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(string separator, params T[] values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            return JoinInternal(separator.AsSpan(), values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(string separator, List<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values);
+        }
+        
+        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
+        public static string Join<T>(string separator, ReadOnlySpan<T> values)
+		{
+            return JoinInternal(separator.AsSpan(), values);
+        }
+
+        public static string Join<T>(string separator, ICollection<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values.AsEnumerable());
+        }
+
+        public static string Join<T>(string separator, IList<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values);
+        }
+
+        public static string Join<T>(string separator, IReadOnlyList<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values.AsEnumerable());
+        }
+
+        public static string Join<T>(string separator, IReadOnlyCollection<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
+        public static string Join<T>(string separator, IEnumerable<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values);
+        }
+
+        static string JoinInternal<T>(ReadOnlySpan<char> separator, IList<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
             try
@@ -238,6 +137,7 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
+
                     var item = values[i];
                     if (typeof(T) == typeof(string))
                     {
@@ -259,8 +159,7 @@ namespace Cysharp.Text
             }
         }
 
-        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
-        public static string Join<T>(string separator, ReadOnlySpan<T> values)
+        static string JoinInternal<T>(ReadOnlySpan<char> separator, ReadOnlySpan<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
             try
@@ -271,6 +170,7 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
+
                     var item = values[i];
                     if (typeof(T) == typeof(string))
                     {
@@ -292,28 +192,7 @@ namespace Cysharp.Text
             }
         }
 
-        public static string Join<T>(string separator, ICollection<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        public static string Join<T>(string separator, IList<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        public static string Join<T>(string separator, IReadOnlyList<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        public static string Join<T>(string separator, IReadOnlyCollection<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
-        public static string Join<T>(string separator, IEnumerable<T> values)
+        static string JoinInternal<T>(ReadOnlySpan<char> separator, IEnumerable<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
             try
@@ -329,6 +208,7 @@ namespace Cysharp.Text
                     {
                         isFirst = false;
                     }
+
                     if (typeof(T) == typeof(string))
                     {
                         if (item != null)

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Cysharp.Text
@@ -45,7 +46,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -68,7 +80,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -90,7 +113,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -117,7 +151,17 @@ namespace Cysharp.Text
                     {
                         isFirst = false;
                     }
-                    sb.Append(item);
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
 
                 return sb.ToString();
@@ -160,7 +204,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -183,7 +238,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -205,7 +271,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -252,7 +329,17 @@ namespace Cysharp.Text
                     {
                         isFirst = false;
                     }
-                    sb.Append(item);
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
 
                 return sb.ToString();

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -158,12 +158,19 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(string value)
         {
+            Append(value.AsSpan());
+        }
+
+        /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(ReadOnlySpan<char> value)
+        {
             if (buffer.Length - index < value.Length)
             {
                 Grow(value.Length);
             }
 
-            value.CopyTo(0, buffer, index, value.Length);
+            value.CopyTo(buffer.AsSpan(index));
             index += value.Length;
         }
 

--- a/src/ZString/ZString.cs
+++ b/src/ZString/ZString.cs
@@ -37,139 +37,27 @@ namespace Cysharp.Text
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, params T[] values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            return Join(separator, (IList<T>)values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, List<T> values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                var count = values.Count;
-                for (int i = 0; i < count; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            return Join(separator, (IList<T>)values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, ReadOnlySpan<T> values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            Span<char> s = stackalloc char[1] { separator };
+            return JoinInternal(s, values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(char separator, IEnumerable<T> values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                var isFirst = true;
-                foreach (var item in values)
-                {
-                    if (!isFirst)
-                    {
-                        sb.Append(separator);
-                    }
-                    else
-                    {
-                        isFirst = false;
-                    }
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            Span<char> s = stackalloc char[1] { separator };
+            return JoinInternal(s, values);
         }
 
         public static string Join<T>(char separator, ICollection<T> values)
@@ -179,7 +67,8 @@ namespace Cysharp.Text
 
         public static string Join<T>(char separator, IList<T> values)
         {
-            return Join(separator, values.AsEnumerable());
+            Span<char> s = stackalloc char[1] { separator };
+            return JoinInternal(s, values);
         }
 
         public static string Join<T>(char separator, IReadOnlyList<T> values)
@@ -195,38 +84,48 @@ namespace Cysharp.Text
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(string separator, params T[] values)
         {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    if (i != 0)
-                    {
-                        sb.Append(separator);
-                    }
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        if (item != null)
-                        {
-                            sb.Append(Unsafe.As<string>(item));
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
+            return JoinInternal(separator.AsSpan(), values);
         }
 
         /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
         public static string Join<T>(string separator, List<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values);
+        }
+        
+        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
+        public static string Join<T>(string separator, ReadOnlySpan<T> values)
+		{
+            return JoinInternal(separator.AsSpan(), values);
+        }
+
+        public static string Join<T>(string separator, ICollection<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values.AsEnumerable());
+        }
+
+        public static string Join<T>(string separator, IList<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values);
+        }
+
+        public static string Join<T>(string separator, IReadOnlyList<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values.AsEnumerable());
+        }
+
+        public static string Join<T>(string separator, IReadOnlyCollection<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
+        public static string Join<T>(string separator, IEnumerable<T> values)
+        {
+            return JoinInternal(separator.AsSpan(), values);
+        }
+
+        static string JoinInternal<T>(ReadOnlySpan<char> separator, IList<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
             try
@@ -238,6 +137,7 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
+
                     var item = values[i];
                     if (typeof(T) == typeof(string))
                     {
@@ -259,8 +159,7 @@ namespace Cysharp.Text
             }
         }
 
-        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
-        public static string Join<T>(string separator, ReadOnlySpan<T> values)
+        static string JoinInternal<T>(ReadOnlySpan<char> separator, ReadOnlySpan<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
             try
@@ -271,6 +170,7 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
+
                     var item = values[i];
                     if (typeof(T) == typeof(string))
                     {
@@ -292,28 +192,7 @@ namespace Cysharp.Text
             }
         }
 
-        public static string Join<T>(string separator, ICollection<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        public static string Join<T>(string separator, IList<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        public static string Join<T>(string separator, IReadOnlyList<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        public static string Join<T>(string separator, IReadOnlyCollection<T> values)
-        {
-            return Join(separator, values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the elements of an array, using the specified seperator between each element.</summary>
-        public static string Join<T>(string separator, IEnumerable<T> values)
+        static string JoinInternal<T>(ReadOnlySpan<char> separator, IEnumerable<T> values)
         {
             var sb = new Utf16ValueStringBuilder(true);
             try
@@ -329,6 +208,7 @@ namespace Cysharp.Text
                     {
                         isFirst = false;
                     }
+
                     if (typeof(T) == typeof(string))
                     {
                         if (item != null)

--- a/src/ZString/ZString.cs
+++ b/src/ZString/ZString.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace Cysharp.Text
@@ -45,7 +46,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -68,7 +80,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -90,7 +113,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -117,7 +151,17 @@ namespace Cysharp.Text
                     {
                         isFirst = false;
                     }
-                    sb.Append(item);
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
 
                 return sb.ToString();
@@ -160,7 +204,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -183,7 +238,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -205,7 +271,18 @@ namespace Cysharp.Text
                     {
                         sb.Append(separator);
                     }
-                    sb.Append(values[i]);
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
                 return sb.ToString();
             }
@@ -252,7 +329,17 @@ namespace Cysharp.Text
                     {
                         isFirst = false;
                     }
-                    sb.Append(item);
+                    if (typeof(T) == typeof(string))
+                    {
+                        if (item != null)
+                        {
+                            sb.Append(Unsafe.As<string>(item));
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
                 }
 
                 return sb.ToString();

--- a/tests/ZString.Tests/JoinTest.cs
+++ b/tests/ZString.Tests/JoinTest.cs
@@ -109,5 +109,28 @@ namespace ZStringTests
             var expected = string.Join(',', new string[] { a, b });
             actrual.Should().Be(expected);
         }
+
+        [Fact]
+        public void JoinStrings()
+        {
+            var values = new[] { "abc", null, "def" };
+            {
+                const char sep = ',';
+                var expected = string.Join(sep, values);
+                ZString.Join(sep, new ReadOnlySpan<string>(values)).Should().Be(expected);
+                ZString.Join(sep, values).Should().Be(expected);
+                ZString.Join(sep, values.ToList()).Should().Be(expected);
+                ZString.Join(sep, values.AsEnumerable()).Should().Be(expected);
+            }
+
+            {
+                const string sep = "_,_";
+                var expected = string.Join(sep, values);
+                ZString.Join(sep, new ReadOnlySpan<string>(values)).Should().Be(expected);
+                ZString.Join(sep, values).Should().Be(expected);
+                ZString.Join(sep, values.ToList()).Should().Be(expected);
+                ZString.Join(sep, values.AsEnumerable()).Should().Be(expected);
+            }
+        }
     }
 }


### PR DESCRIPTION
ZString.Join is faster than System.Join. See #17 
(But for String[] cases, String.Join is faster.)

And we've added the following methods that are needed to clean up the code.

```cs
public partial struct Utf16ValueStringBuilder
{
    public void Append(ReadOnlySpan<char> value);
}
```