### PR TITLE
Implement ZString.Concat works as same as string.Concat on collection types

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
@@ -126,6 +126,54 @@ namespace Cysharp.Text
             return JoinInternal(separator.AsSpan(), values);
         }
 
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(params T[] values)
+        {
+            return JoinInternal<T>(default, values.AsSpan());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(List<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ReadOnlySpan<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ICollection<T> values)
+        {
+            return JoinInternal(default, values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IList<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyList<T> values)
+        {
+            return JoinInternal(default, values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyCollection<T> values)
+        {
+            return JoinInternal(default, values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IEnumerable<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
         static string JoinInternal<T>(ReadOnlySpan<char> separator, IList<T> values)
         {
             var count = values.Count;
@@ -230,160 +278,6 @@ namespace Cysharp.Text
                         isFirst = false;
                     }
 
-                    if (typeof(T) == typeof(string))
-                    {
-                        var s = Unsafe.As<string>(item);
-                        if (!string.IsNullOrEmpty(s))
-                        {
-                            sb.Append(s);
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(params T[] values)
-        {
-            return ConcatInternal<T>(values.AsSpan());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(List<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(ReadOnlySpan<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(ICollection<T> values)
-        {
-            return ConcatInternal(values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IList<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IReadOnlyList<T> values)
-        {
-            return ConcatInternal(values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IReadOnlyCollection<T> values)
-        {
-            return ConcatInternal(values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IEnumerable<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        static string ConcatInternal<T>(IList<T> values)
-        {
-            var count = values.Count;
-            if (count == 0)
-            {
-                return string.Empty;
-            }
-            else if (typeof(T) == typeof(string) && count == 1)
-            {
-                return Unsafe.As<string>(values[0]);
-            }
-
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        var s = Unsafe.As<string>(item);
-                        if (!string.IsNullOrEmpty(s))
-                        {
-                            sb.Append(s);
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
-        }
-
-        static string ConcatInternal<T>(ReadOnlySpan<T> values)
-        {
-            if (values.Length == 0)
-            {
-                return string.Empty;
-            }
-            else if (typeof(T) == typeof(string) && values.Length == 1)
-            {
-                return Unsafe.As<string>(values[0]);
-            }
-
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        var s = Unsafe.As<string>(item);
-                        if (!string.IsNullOrEmpty(s))
-                        {
-                            sb.Append(s);
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
-        }
-
-        static string ConcatInternal<T>(IEnumerable<T> values)
-        {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                foreach (var item in values)
-                {
                     if (typeof(T) == typeof(string))
                     {
                         var s = Unsafe.As<string>(item);

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
@@ -251,5 +251,159 @@ namespace Cysharp.Text
                 sb.Dispose();
             }
         }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(params T[] values)
+        {
+            return ConcatInternal<T>(values.AsSpan());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(List<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ReadOnlySpan<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ICollection<T> values)
+        {
+            return ConcatInternal(values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IList<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyList<T> values)
+        {
+            return ConcatInternal(values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyCollection<T> values)
+        {
+            return ConcatInternal(values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IEnumerable<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        static string ConcatInternal<T>(IList<T> values)
+        {
+            var count = values.Count;
+            if (count == 0)
+            {
+                return string.Empty;
+            }
+            else if (typeof(T) == typeof(string) && count == 1)
+            {
+                return Unsafe.As<string>(values[0]);
+            }
+
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        var s = Unsafe.As<string>(item);
+                        if (!string.IsNullOrEmpty(s))
+                        {
+                            sb.Append(s);
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
+                }
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+
+        static string ConcatInternal<T>(ReadOnlySpan<T> values)
+        {
+            if (values.Length == 0)
+            {
+                return string.Empty;
+            }
+            else if (typeof(T) == typeof(string) && values.Length == 1)
+            {
+                return Unsafe.As<string>(values[0]);
+            }
+
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        var s = Unsafe.As<string>(item);
+                        if (!string.IsNullOrEmpty(s))
+                        {
+                            sb.Append(s);
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
+                }
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+
+        static string ConcatInternal<T>(IEnumerable<T> values)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                foreach (var item in values)
+                {
+                    if (typeof(T) == typeof(string))
+                    {
+                        var s = Unsafe.As<string>(item);
+                        if (!string.IsNullOrEmpty(s))
+                        {
+                            sb.Append(s);
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
+                }
+
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
     }
 }

--- a/src/ZString/ZString.cs
+++ b/src/ZString/ZString.cs
@@ -126,6 +126,54 @@ namespace Cysharp.Text
             return JoinInternal(separator.AsSpan(), values);
         }
 
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(params T[] values)
+        {
+            return JoinInternal<T>(default, values.AsSpan());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(List<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ReadOnlySpan<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ICollection<T> values)
+        {
+            return JoinInternal(default, values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IList<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyList<T> values)
+        {
+            return JoinInternal(default, values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyCollection<T> values)
+        {
+            return JoinInternal(default, values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IEnumerable<T> values)
+        {
+            return JoinInternal(default, values);
+        }
+
         static string JoinInternal<T>(ReadOnlySpan<char> separator, IList<T> values)
         {
             var count = values.Count;
@@ -230,160 +278,6 @@ namespace Cysharp.Text
                         isFirst = false;
                     }
 
-                    if (typeof(T) == typeof(string))
-                    {
-                        var s = Unsafe.As<string>(item);
-                        if (!string.IsNullOrEmpty(s))
-                        {
-                            sb.Append(s);
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(params T[] values)
-        {
-            return ConcatInternal<T>(values.AsSpan());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(List<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(ReadOnlySpan<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(ICollection<T> values)
-        {
-            return ConcatInternal(values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IList<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IReadOnlyList<T> values)
-        {
-            return ConcatInternal(values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IReadOnlyCollection<T> values)
-        {
-            return ConcatInternal(values.AsEnumerable());
-        }
-
-        /// <summary>Concatenates the string representation of some specified objects.</summary>
-        public static string Concat<T>(IEnumerable<T> values)
-        {
-            return ConcatInternal(values);
-        }
-
-        static string ConcatInternal<T>(IList<T> values)
-        {
-            var count = values.Count;
-            if (count == 0)
-            {
-                return string.Empty;
-            }
-            else if (typeof(T) == typeof(string) && count == 1)
-            {
-                return Unsafe.As<string>(values[0]);
-            }
-
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < count; i++)
-                {
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        var s = Unsafe.As<string>(item);
-                        if (!string.IsNullOrEmpty(s))
-                        {
-                            sb.Append(s);
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
-        }
-
-        static string ConcatInternal<T>(ReadOnlySpan<T> values)
-        {
-            if (values.Length == 0)
-            {
-                return string.Empty;
-            }
-            else if (typeof(T) == typeof(string) && values.Length == 1)
-            {
-                return Unsafe.As<string>(values[0]);
-            }
-
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                for (int i = 0; i < values.Length; i++)
-                {
-                    var item = values[i];
-                    if (typeof(T) == typeof(string))
-                    {
-                        var s = Unsafe.As<string>(item);
-                        if (!string.IsNullOrEmpty(s))
-                        {
-                            sb.Append(s);
-                        }
-                    }
-                    else
-                    {
-                        sb.Append(item);
-                    }
-                }
-                return sb.ToString();
-            }
-            finally
-            {
-                sb.Dispose();
-            }
-        }
-
-        static string ConcatInternal<T>(IEnumerable<T> values)
-        {
-            var sb = new Utf16ValueStringBuilder(true);
-            try
-            {
-                foreach (var item in values)
-                {
                     if (typeof(T) == typeof(string))
                     {
                         var s = Unsafe.As<string>(item);

--- a/src/ZString/ZString.cs
+++ b/src/ZString/ZString.cs
@@ -251,5 +251,159 @@ namespace Cysharp.Text
                 sb.Dispose();
             }
         }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(params T[] values)
+        {
+            return ConcatInternal<T>(values.AsSpan());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(List<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ReadOnlySpan<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(ICollection<T> values)
+        {
+            return ConcatInternal(values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IList<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyList<T> values)
+        {
+            return ConcatInternal(values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IReadOnlyCollection<T> values)
+        {
+            return ConcatInternal(values.AsEnumerable());
+        }
+
+        /// <summary>Concatenates the string representation of some specified objects.</summary>
+        public static string Concat<T>(IEnumerable<T> values)
+        {
+            return ConcatInternal(values);
+        }
+
+        static string ConcatInternal<T>(IList<T> values)
+        {
+            var count = values.Count;
+            if (count == 0)
+            {
+                return string.Empty;
+            }
+            else if (typeof(T) == typeof(string) && count == 1)
+            {
+                return Unsafe.As<string>(values[0]);
+            }
+
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        var s = Unsafe.As<string>(item);
+                        if (!string.IsNullOrEmpty(s))
+                        {
+                            sb.Append(s);
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
+                }
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+
+        static string ConcatInternal<T>(ReadOnlySpan<T> values)
+        {
+            if (values.Length == 0)
+            {
+                return string.Empty;
+            }
+            else if (typeof(T) == typeof(string) && values.Length == 1)
+            {
+                return Unsafe.As<string>(values[0]);
+            }
+
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                for (int i = 0; i < values.Length; i++)
+                {
+                    var item = values[i];
+                    if (typeof(T) == typeof(string))
+                    {
+                        var s = Unsafe.As<string>(item);
+                        if (!string.IsNullOrEmpty(s))
+                        {
+                            sb.Append(s);
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
+                }
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+
+        static string ConcatInternal<T>(IEnumerable<T> values)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                foreach (var item in values)
+                {
+                    if (typeof(T) == typeof(string))
+                    {
+                        var s = Unsafe.As<string>(item);
+                        if (!string.IsNullOrEmpty(s))
+                        {
+                            sb.Append(s);
+                        }
+                    }
+                    else
+                    {
+                        sb.Append(item);
+                    }
+                }
+
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
     }
 }

--- a/tests/ZString.Tests/JoinTest.cs
+++ b/tests/ZString.Tests/JoinTest.cs
@@ -132,5 +132,17 @@ namespace ZStringTests
                 ZString.Join(sep, values.AsEnumerable()).Should().Be(expected);
             }
         }
+
+        [Fact]
+        public void ConcatStrings()
+        {
+            var values = new[] { "abc", null, "def" };
+
+            var expected = string.Concat(values);
+            ZString.Concat(new ReadOnlySpan<string>(values)).Should().Be(expected);
+            ZString.Concat(values).Should().Be(expected);
+            ZString.Concat(values.ToList()).Should().Be(expected);
+            ZString.Concat(values.AsEnumerable()).Should().Be(expected);
+        }
     }
 }


### PR DESCRIPTION
Using of ZString.Concat on collection types leads to the wrong result that users would expecting the result as same as string.Concat.

https://github.com/Cysharp/ZString/compare/master...piti6:implement-Concat-from-collections?expand=1#diff-eb70c70af0fdc6be03f85a109ae3909dR136-R145

Expected: Test succeeds without failure.
Result:
```
Expected ZString.Concat(values) to be 
    "abcdef" with a length of 6, but 
    "System.String[]" has a length of 15, differs near "Sys" (index 0).
```