### PR TITLE
Add some BCL-like methods to StringBuilder 

### DIFF
--- a/sandbox/PerfBenchmark/Benchmarks/ReplaceBenchmark.cs
+++ b/sandbox/PerfBenchmark/Benchmarks/ReplaceBenchmark.cs
@@ -1,0 +1,189 @@
+﻿using BenchmarkDotNet.Attributes;
+using Cysharp.Text;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Formatting;
+
+namespace PerfBenchmark.Benchmarks
+{
+    [Config(typeof(BenchmarkConfig))]
+    public class ReplaceBenchmark
+    {
+        StringBuilder bcl;
+
+        string text = "The quick brown fox jumped over the lazy dogs.";
+        string largeText;
+
+        string guid = Guid.NewGuid().ToString();
+
+        readonly string[] csharpKeywords =
+        {
+            "abstract",
+            "as",
+            "async",
+            "await",
+            "base",
+            "bool",
+            "break",
+            "byte",
+            "case",
+            "catch",
+            "char",
+            "checked",
+            "class",
+            "const",
+            "continue",
+            "decimal",
+            "default",
+            "delegate",
+            "do",
+            "double",
+            "else",
+            "enum",
+            "event",
+            "explicit",
+            "extern",
+            "false",
+            "finally",
+            "fixed",
+            "float",
+            "for",
+            "foreach",
+            "goto",
+            "if",
+            "implicit",
+            "in",
+            "int",
+            "interface",
+            "internal",
+            "is",
+            "lock",
+            "long",
+            "namespace",
+            "new",
+            "null",
+            "object",
+            "operator",
+            "out",
+            "override",
+            "params",
+            "private",
+            "protected",
+            "public",
+            "readonly",
+            "ref",
+            "return",
+            "sbyte",
+            "sealed",
+            "short",
+            "sizeof",
+            "stackalloc",
+            "static",
+            "string",
+            "struct",
+            "switch",
+            "this",
+            "throw",
+            "true",
+            "try",
+            "typeof",
+            "uint",
+            "ulong",
+            "unchecked",
+            "unsafe",
+            "ushort",
+            "using",
+            "virtual",
+            "volatile",
+            "void",
+            "while",
+        };
+
+        private static string GetThisFilePath([System.Runtime.CompilerServices.CallerFilePath] string path = null) => path;
+
+        public ReplaceBenchmark()
+        {
+            bcl = new StringBuilder();
+            largeText = System.IO.File.ReadAllText(GetThisFilePath()); //read this file
+            if (largeText.Length < 2048)
+                throw new Exception();
+        }
+
+        [Benchmark]
+        public int ReplaceChar()
+        {
+            bcl.Clear();
+            return bcl.Append(text).Replace(' ', '\n').Length;
+        }
+
+        [Benchmark]
+        public int ZReplaceChar()
+        {
+            using var zsb = ZString.CreateStringBuilder(true);
+            zsb.Append(text);
+            zsb.Replace(' ', '\n');
+            return zsb.Length; // Use Length to avoid omitting it
+        }
+
+        [Benchmark]
+        public int ReplaceString()
+        {
+            bcl.Clear();
+            return bcl.Append(text).Replace(" ", "\r\n").Length; // Use Length to avoid omitting it
+        }
+
+        [Benchmark]
+        public int ZReplaceString()
+        {
+            using var zsb = ZString.CreateStringBuilder(true);
+            zsb.Append(text);
+            zsb.Replace(" ", "\r\n");
+            return zsb.Length; // Use Length to avoid omitting it
+        }
+
+        [Benchmark]
+        public int NotReplaced()
+        {
+            bcl.Clear();
+            bcl.Append(largeText);
+            bcl.Replace(guid, "XXXXXX"); // GUID value should not be included in this file.
+            return bcl.Length; // Use Length to avoid omitting it
+        }
+
+        [Benchmark]
+        public int ZNotReplaced()
+        {
+            using var zsb = ZString.CreateStringBuilder(true);
+            zsb.Append(text);
+            zsb.Replace(guid, "XXXXXX"); // GUID value should not be included in this file.
+            return zsb.Length; // Use Length to avoid omitting it
+        }
+
+        [Benchmark]
+        public int ManyTimesReplace()
+        {
+            bcl.Clear();
+            bcl.Append(largeText);
+            // remove all keywords
+            foreach (var keyword in csharpKeywords)
+            {
+                bcl.Replace(keyword, "");
+            }
+            return bcl.Length; // Use Length to avoid omitting it
+        }
+
+        [Benchmark]
+        public int ZManyTimesReplace()
+        {
+            using var zsb = ZString.CreateStringBuilder(true);
+            zsb.Append(text);
+            // remove all keywords
+            foreach (var keyword in csharpKeywords)
+            {
+                zsb.Replace(keyword, "");
+            }
+            return zsb.Length; // Use Length to avoid omitting it
+        }
+    }
+}

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -362,6 +362,44 @@ namespace Cysharp.Text
             index = newBufferIndex;
         }
 
+        /// <summary>
+        /// Removes a range of characters from this builder.
+        /// </summary>
+        /// <remarks>
+        /// This method does not reduce the capacity of this builder.
+        /// </remarks>
+        public void Remove(int startIndex, int length)
+        {
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex));
+            }
+
+            if (length > Length - startIndex)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (Length == length && startIndex == 0)
+            {
+                index = 0;
+                return;
+            }
+
+            if (length == 0)
+            {
+                return;
+            }
+
+            buffer.AsSpan(startIndex + length).CopyTo(buffer.AsSpan(startIndex));
+            index -= length;
+        }
+
         // Output
 
         /// <summary>Copy inner buffer to the destination span.</summary>

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -87,6 +87,11 @@ namespace Cysharp.Text
             index = 0;
         }
 
+        public void Clear()
+        {
+            index = 0;
+        }
+
         public void TryGrow(int sizeHint)
         {
 
@@ -146,6 +151,18 @@ namespace Cysharp.Text
             buffer[index++] = value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char value, int repeatCount)
+        {
+            if (repeatCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(repeatCount));
+            }
+
+            GetSpan(repeatCount).Fill(value);
+            Advance(repeatCount);
+        }
+
         /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AppendLine(char value)
@@ -161,6 +178,14 @@ namespace Cysharp.Text
             Append(value.AsSpan());
         }
 
+        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(string value)
+        {
+            Append(value);
+            AppendLine();
+        }
+
         /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(ReadOnlySpan<char> value)
@@ -174,9 +199,8 @@ namespace Cysharp.Text
             index += value.Length;
         }
 
-        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AppendLine(string value)
+        public void AppendLine(ReadOnlySpan<char> value)
         {
             Append(value);
             AppendLine();

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
@@ -168,18 +168,26 @@ namespace Cysharp.Text
                 throw new ArgumentOutOfRangeException(nameof(repeatCount));
             }
 
-            var maxLen = UTF8NoBom.GetMaxByteCount(1);
-            Span<byte> utf8Bytes = stackalloc byte[maxLen];
-            ReadOnlySpan<char> chars = stackalloc char[1] { value };
-
-            int len = UTF8NoBom.GetBytes(chars, utf8Bytes);
-
-            TryGrow(len * repeatCount);
-
-            for (int i = 0; i < repeatCount; i++)
+            if (value <= 0x7F) // ASCII
             {
-                utf8Bytes.CopyTo(GetSpan(len));
-                Advance(len);
+                GetSpan(repeatCount).Fill((byte)value);
+                Advance(repeatCount);
+            }
+            else
+            { 
+                var maxLen = UTF8NoBom.GetMaxByteCount(1);
+                Span<byte> utf8Bytes = stackalloc byte[maxLen];
+                ReadOnlySpan<char> chars = stackalloc char[1] { value };
+
+                int len = UTF8NoBom.GetBytes(chars, utf8Bytes);
+
+                TryGrow(len * repeatCount);
+
+                for (int i = 0; i < repeatCount; i++)
+                {
+                    utf8Bytes.CopyTo(GetSpan(len));
+                    Advance(len);
+                }
             }
         }
 

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
@@ -93,6 +93,11 @@ namespace Cysharp.Text
             index = 0;
         }
 
+        public void Clear()
+        {
+            index = 0;
+        }
+
         public void TryGrow(int sizeHint)
         {
             if (buffer.Length < index + sizeHint)
@@ -155,6 +160,29 @@ namespace Cysharp.Text
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char value, int repeatCount)
+        {
+            if (repeatCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(repeatCount));
+            }
+
+            var maxLen = UTF8NoBom.GetMaxByteCount(1);
+            Span<byte> utf8Bytes = stackalloc byte[maxLen];
+            ReadOnlySpan<char> chars = stackalloc char[1] { value };
+
+            int len = UTF8NoBom.GetBytes(chars, utf8Bytes);
+
+            TryGrow(len * repeatCount);
+
+            for (int i = 0; i < repeatCount; i++)
+            {
+                utf8Bytes.CopyTo(GetSpan(len));
+                Advance(len);
+            }
+        }
+
         /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AppendLine(char value)
@@ -167,18 +195,32 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(string value)
         {
+            Append(value.AsSpan());
+        }
+
+        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(string value)
+        {
+            Append(value);
+            AppendLine();
+        }
+
+        /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(ReadOnlySpan<char> value)
+        {
             var maxLen = UTF8NoBom.GetMaxByteCount(value.Length);
             if (buffer.Length - index < maxLen)
             {
                 Grow(maxLen);
             }
 
-            index += UTF8NoBom.GetBytes(value, 0, value.Length, buffer, index);
+            index += UTF8NoBom.GetBytes(value, buffer.AsSpan(index));
         }
 
-        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AppendLine(string value)
+        public void AppendLine(ReadOnlySpan<char> value)
         {
             Append(value);
             AppendLine();

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -362,6 +362,44 @@ namespace Cysharp.Text
             index = newBufferIndex;
         }
 
+        /// <summary>
+        /// Removes a range of characters from this builder.
+        /// </summary>
+        /// <remarks>
+        /// This method does not reduce the capacity of this builder.
+        /// </remarks>
+        public void Remove(int startIndex, int length)
+        {
+            if (length < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (startIndex < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(startIndex));
+            }
+
+            if (length > Length - startIndex)
+            {
+                throw new ArgumentOutOfRangeException(nameof(length));
+            }
+
+            if (Length == length && startIndex == 0)
+            {
+                index = 0;
+                return;
+            }
+
+            if (length == 0)
+            {
+                return;
+            }
+
+            buffer.AsSpan(startIndex + length).CopyTo(buffer.AsSpan(startIndex));
+            index -= length;
+        }
+
         // Output
 
         /// <summary>Copy inner buffer to the destination span.</summary>

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -87,6 +87,11 @@ namespace Cysharp.Text
             index = 0;
         }
 
+        public void Clear()
+        {
+            index = 0;
+        }
+
         public void TryGrow(int sizeHint)
         {
 
@@ -146,6 +151,18 @@ namespace Cysharp.Text
             buffer[index++] = value;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char value, int repeatCount)
+        {
+            if (repeatCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(repeatCount));
+            }
+
+            GetSpan(repeatCount).Fill(value);
+            Advance(repeatCount);
+        }
+
         /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AppendLine(char value)
@@ -161,6 +178,14 @@ namespace Cysharp.Text
             Append(value.AsSpan());
         }
 
+        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(string value)
+        {
+            Append(value);
+            AppendLine();
+        }
+
         /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(ReadOnlySpan<char> value)
@@ -174,9 +199,8 @@ namespace Cysharp.Text
             index += value.Length;
         }
 
-        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AppendLine(string value)
+        public void AppendLine(ReadOnlySpan<char> value)
         {
             Append(value);
             AppendLine();

--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -168,18 +168,26 @@ namespace Cysharp.Text
                 throw new ArgumentOutOfRangeException(nameof(repeatCount));
             }
 
-            var maxLen = UTF8NoBom.GetMaxByteCount(1);
-            Span<byte> utf8Bytes = stackalloc byte[maxLen];
-            ReadOnlySpan<char> chars = stackalloc char[1] { value };
-
-            int len = UTF8NoBom.GetBytes(chars, utf8Bytes);
-
-            TryGrow(len * repeatCount);
-
-            for (int i = 0; i < repeatCount; i++)
+            if (value <= 0x7F) // ASCII
             {
-                utf8Bytes.CopyTo(GetSpan(len));
-                Advance(len);
+                GetSpan(repeatCount).Fill((byte)value);
+                Advance(repeatCount);
+            }
+            else
+            { 
+                var maxLen = UTF8NoBom.GetMaxByteCount(1);
+                Span<byte> utf8Bytes = stackalloc byte[maxLen];
+                ReadOnlySpan<char> chars = stackalloc char[1] { value };
+
+                int len = UTF8NoBom.GetBytes(chars, utf8Bytes);
+
+                TryGrow(len * repeatCount);
+
+                for (int i = 0; i < repeatCount; i++)
+                {
+                    utf8Bytes.CopyTo(GetSpan(len));
+                    Advance(len);
+                }
             }
         }
 

--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -93,6 +93,11 @@ namespace Cysharp.Text
             index = 0;
         }
 
+        public void Clear()
+        {
+            index = 0;
+        }
+
         public void TryGrow(int sizeHint)
         {
             if (buffer.Length < index + sizeHint)
@@ -155,6 +160,29 @@ namespace Cysharp.Text
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char value, int repeatCount)
+        {
+            if (repeatCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(repeatCount));
+            }
+
+            var maxLen = UTF8NoBom.GetMaxByteCount(1);
+            Span<byte> utf8Bytes = stackalloc byte[maxLen];
+            ReadOnlySpan<char> chars = stackalloc char[1] { value };
+
+            int len = UTF8NoBom.GetBytes(chars, utf8Bytes);
+
+            TryGrow(len * repeatCount);
+
+            for (int i = 0; i < repeatCount; i++)
+            {
+                utf8Bytes.CopyTo(GetSpan(len));
+                Advance(len);
+            }
+        }
+
         /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void AppendLine(char value)
@@ -167,18 +195,32 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(string value)
         {
+            Append(value.AsSpan());
+        }
+
+        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(string value)
+        {
+            Append(value);
+            AppendLine();
+        }
+
+        /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(ReadOnlySpan<char> value)
+        {
             var maxLen = UTF8NoBom.GetMaxByteCount(value.Length);
             if (buffer.Length - index < maxLen)
             {
                 Grow(maxLen);
             }
 
-            index += UTF8NoBom.GetBytes(value, 0, value.Length, buffer, index);
+            index += UTF8NoBom.GetBytes(value, buffer.AsSpan(index));
         }
 
-        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void AppendLine(string value)
+        public void AppendLine(ReadOnlySpan<char> value)
         {
             Append(value);
             AppendLine();

--- a/tests/ZString.Tests/InsertTest.cs
+++ b/tests/ZString.Tests/InsertTest.cs
@@ -1,0 +1,71 @@
+using Cysharp.Text;
+using FluentAssertions;
+using System.Text;
+using Xunit;
+
+namespace ZStringTests
+{
+    public class InsertTest
+    {
+        [Fact]
+        public void InsertStringTest()
+        { 
+            string initialValue = "--[]--";
+
+            using (var zsb = ZString.CreateStringBuilder(notNested: true))
+            {
+                string xyz = "xyz";
+
+                zsb.Append(initialValue);
+                var bcl = new StringBuilder(initialValue);
+
+                zsb.Insert(3, xyz, 2);
+                bcl.Insert(3, xyz, 2);
+                zsb.ToString().Should().Be(bcl.ToString());
+
+                zsb.Insert(3, xyz);
+                bcl.Insert(3, xyz);
+                zsb.ToString().Should().Be(bcl.ToString());
+
+                zsb.Insert(0, "<<");
+                bcl.Insert(0, "<<");
+                zsb.ToString().Should().Be(bcl.ToString());
+
+                var endIndex = zsb.Length - 1;
+                zsb.Insert(endIndex, ">>");
+                bcl.Insert(endIndex, ">>");
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
+        }
+
+        [Fact]
+        public void InsertLargeStringTest()
+        {
+            string initialValue = "--[]--";
+
+            using (var zsb = ZString.CreateStringBuilder(notNested: true))
+            {
+                string text = new string('X', 32768);
+
+                zsb.Append(initialValue);
+                var bcl = new StringBuilder(initialValue);
+
+                zsb.Insert(3, text);
+                bcl.Insert(3, text);
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
+        }
+
+        [Fact]
+        public void NotInserted()
+        {
+            using (var zsb = ZString.CreateStringBuilder(notNested: true))
+            {
+                var text = "The quick brown dog jumps over the lazy cat.";
+                zsb.Append(text);
+                zsb.Insert( 10, "");
+                zsb.ToString().Should().Be(text);
+            }
+        }
+    }
+}

--- a/tests/ZString.Tests/RemoveTest.cs
+++ b/tests/ZString.Tests/RemoveTest.cs
@@ -1,0 +1,53 @@
+﻿using Cysharp.Text;
+using FluentAssertions;
+using System.Text;
+using Xunit;
+
+namespace ZStringTests
+{
+    public class RemoveTest
+    { 
+        [Fact]
+        public void RemovePart()
+        {
+            string str = "The quick brown fox jumps over the lazy dog.";
+            using var zsb = ZString.CreateStringBuilder();
+            zsb.Append(str);
+            var bcl = new StringBuilder(str);
+
+            // Remove "brown "
+            zsb.Remove(10, 6);
+            bcl.Remove(10, 6);
+
+            zsb.ToString().Should().Be(bcl.ToString());
+        }
+
+        [Fact]
+        public void RemoveAll()
+        {
+            string str = "The quick brown fox jumps over the lazy dog.";
+            using var zsb = ZString.CreateStringBuilder();
+            zsb.Append(str);
+            var bcl = new StringBuilder(str);
+
+            zsb.Remove(0, str.Length);
+            bcl.Remove(0, str.Length);
+
+            zsb.ToString().Should().Be(bcl.ToString());
+        }
+
+        [Fact]
+        public void RemoveTail()
+        {
+            string str = "foo,bar,baz";
+            using var zsb = ZString.CreateStringBuilder();
+            zsb.Append(str);
+            var bcl = new StringBuilder(str);
+
+            zsb.Remove(7, 4);
+            bcl.Remove(7, 4);
+
+            zsb.ToString().Should().Be(bcl.ToString());
+        }
+    }
+}

--- a/tests/ZString.Tests/RemoveTest.cs
+++ b/tests/ZString.Tests/RemoveTest.cs
@@ -11,43 +11,49 @@ namespace ZStringTests
         public void RemovePart()
         {
             string str = "The quick brown fox jumps over the lazy dog.";
-            using var zsb = ZString.CreateStringBuilder();
-            zsb.Append(str);
-            var bcl = new StringBuilder(str);
+            using (var zsb = ZString.CreateStringBuilder())
+            {
+                zsb.Append(str);
+                var bcl = new StringBuilder(str);
 
-            // Remove "brown "
-            zsb.Remove(10, 6);
-            bcl.Remove(10, 6);
+                // Remove "brown "
+                zsb.Remove(10, 6);
+                bcl.Remove(10, 6);
 
-            zsb.ToString().Should().Be(bcl.ToString());
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
         }
 
         [Fact]
         public void RemoveAll()
         {
             string str = "The quick brown fox jumps over the lazy dog.";
-            using var zsb = ZString.CreateStringBuilder();
-            zsb.Append(str);
-            var bcl = new StringBuilder(str);
+            using (var zsb = ZString.CreateStringBuilder())
+            {
+                zsb.Append(str);
+                var bcl = new StringBuilder(str);
 
-            zsb.Remove(0, str.Length);
-            bcl.Remove(0, str.Length);
+                zsb.Remove(0, str.Length);
+                bcl.Remove(0, str.Length);
 
-            zsb.ToString().Should().Be(bcl.ToString());
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
         }
 
         [Fact]
         public void RemoveTail()
         {
             string str = "foo,bar,baz";
-            using var zsb = ZString.CreateStringBuilder();
-            zsb.Append(str);
-            var bcl = new StringBuilder(str);
+            using (var zsb = ZString.CreateStringBuilder())
+            {
+                zsb.Append(str);
+                var bcl = new StringBuilder(str);
 
-            zsb.Remove(7, 4);
-            bcl.Remove(7, 4);
+                zsb.Remove(7, 4);
+                bcl.Remove(7, 4);
 
-            zsb.ToString().Should().Be(bcl.ToString());
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
         }
     }
 }

--- a/tests/ZString.Tests/ReplaceTest.cs
+++ b/tests/ZString.Tests/ReplaceTest.cs
@@ -43,6 +43,19 @@ namespace ZStringTests
                 zsb.ToString().Should().Be(bcl.ToString());
             }
 
+            using (var zsb = ZString.CreateStringBuilder(notNested: true))
+            {
+                var text = "num num num";
+                zsb.Append(text);
+                var bcl = new StringBuilder(text);
+
+                // over DefaultBufferSize
+                zsb.Replace("num", new string('1', 32768), 1, text.Length - 2);
+                bcl.Replace("num", new string('1', 32768), 1, text.Length - 2);
+
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
+
             using (var zsb = ZString.CreateStringBuilder())
             {
                 var text = "The quick brown dog jumps over the lazy cat.";

--- a/tests/ZString.Tests/ReplaceTest.cs
+++ b/tests/ZString.Tests/ReplaceTest.cs
@@ -1,0 +1,76 @@
+using Cysharp.Text;
+using FluentAssertions;
+using System.Text;
+using Xunit;
+
+namespace ZStringTests
+{
+    public class ReplaceTest
+    {
+        [Fact]
+        public void ReplaceCharTest()
+        {
+            var s = new string(' ', 10);
+            using (var zsb = ZString.CreateStringBuilder())
+            {
+                zsb.Append(s);
+                zsb.Replace(' ', '-', 2, 5);
+                zsb.ToString().Should().Be(new StringBuilder(s).Replace(' ', '-', 2, 5).ToString());
+            }
+
+            s = "0";
+            using (var zsb = ZString.CreateStringBuilder())
+            {
+                zsb.Append(s);
+                zsb.Replace('0', '1');
+                zsb.ToString().Should().Be(new StringBuilder(s).Replace('0', '1').ToString());
+            }
+        }
+
+        [Fact]
+        public void ReplaceStringTest()
+        {
+            using (var zsb = ZString.CreateStringBuilder(notNested: true))
+            {
+                var text = "bra bra BRA bra bra";
+                zsb.Append(text);
+                var bcl = new StringBuilder(text);
+                
+                zsb.Replace("bra", null, 1, text.Length - 2);
+                bcl.Replace("bra", null, 1, text.Length - 2);
+
+                //  "bra BRA bra"
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
+
+            using (var zsb = ZString.CreateStringBuilder())
+            {
+                var text = "The quick brown dog jumps over the lazy cat.";
+                zsb.Append(text);
+                var bcl = new StringBuilder(text);
+
+                // All "cat" -> "dog"
+                zsb.Replace("cat", "dog");
+                bcl.Replace("cat", "dog");
+                zsb.ToString().Should().Be(bcl.ToString());
+
+                // Some "dog" -> "fox"
+                zsb.Replace("dog", "fox", 15, 20);
+                bcl.Replace("dog", "fox", 15, 20);
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
+        }
+        
+        [Fact]
+        public void NotMatchTest()
+        {
+            using (var zsb = ZString.CreateStringBuilder(notNested: true))
+            {
+                var text = "The quick brown dog jumps over the lazy cat.";
+                zsb.Append(text);
+                zsb.Replace("pig", "dog");
+                zsb.ToString().Should().Be(text);
+            }
+        }
+    }
+}

--- a/tests/ZString.Tests/Utf8StringBuilderTest.cs
+++ b/tests/ZString.Tests/Utf8StringBuilderTest.cs
@@ -1,0 +1,40 @@
+﻿using Cysharp.Text;
+using FluentAssertions;
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace ZStringTests
+{
+    public class Utf8StringBuilderTest
+    {
+
+        [Fact]
+        public void AppendCharRepeat()
+        {
+            using (var zsb = ZString.CreateUtf8StringBuilder(notNested: true))
+            {
+                var text = "foo";
+                zsb.Append(text);
+                var bcl = new StringBuilder(text);
+
+                // ASCII
+                zsb.Append('\x7F', 10);
+                bcl.Append('\x7F', 10);
+                zsb.ToString().Should().Be(bcl.ToString());
+
+                // Non-ASCII
+                zsb.Append('\x80', 10);
+                bcl.Append('\x80', 10);
+                zsb.ToString().Should().Be(bcl.ToString());
+
+                zsb.Append('\u9bd6', 10);
+                bcl.Append('\u9bd6', 10);
+                zsb.ToString().Should().Be(bcl.ToString());
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
Add the following methods.

```csharp
struct Utf8ValueStringBuilder
{
  void Append(char value, int repeatCount);
  void Append(ReadOnlySpan<char> value);
  void AppendLine(ReadOnlySpan<char> value);
  void Clear();
}
struct Utf16ValueStringBuilder
{
  void Append(char value, int repeatCount);
  void AppendLine(ReadOnlySpan<char> value);
  void Clear();
  void Replace(char oldChar, char newChar);
  void Replace(char oldChar, char newChar, int startIndex, int count);
  void Replace(string oldValue, string newValue);
  void Replace(ReadOnlySpan<char> oldValue, ReadOnlySpan<char> newValue);
  void Replace(string oldValue, string newValue, int startIndex, int count);
  void Replace(ReadOnlySpan<char> oldValue, ReadOnlySpan<char> newValue, int startIndex, int count);
  void Remove(int startIndex, int length);
  void Insert(int index, string value, int count);
  void Insert(int index, string value);
  void Insert(int index, ReadOnlySpan<char> value, int count);
}
```

The `Replace` method has a speed and allocation advantage.
see [sandbox/PerfBenchmark/Benchmarks/ReplaceBenchmark.cs](sandbox/PerfBenchmark/Benchmarks/ReplaceBenchmark.cs)
<details>

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.400-preview-015178
  [Host]   : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  ShortRun : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT

Job=ShortRun  IterationCount=1  LaunchCount=1
WarmupCount=1
```

|            Method |            Mean | Error |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------:|----------------:|------:|-------:|------:|------:|----------:|
|       ReplaceChar |        56.17 ns |    NA |      - |     - |     - |         - |
|      ZReplaceChar |        49.23 ns |    NA |      - |     - |     - |         - |
|     ReplaceString |       465.33 ns |    NA | 0.0448 |     - |     - |     376 B |
|    ZReplaceString |       487.78 ns |    NA |      - |     - |     - |         - |
|       NotReplaced |    16,293.42 ns |    NA |      - |     - |     - |         - |
|      ZNotReplaced |        40.65 ns |    NA |      - |     - |     - |         - |
|  ManyTimesReplace | 1,436,636.52 ns |    NA |      - |     - |     - |    4240 B |
| ZManyTimesReplace |     3,029.78 ns |    NA |      - |     - |     - |         - |

