### PR TITLE
Make throw NestedStringBuilderCreationException on nested StringBuilder creation.

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/NestedStringBuilderCreationException.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/NestedStringBuilderCreationException.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Cysharp.Text
+{
+    // Currently, this class is internals.
+    internal class NestedStringBuilderCreationException : InvalidOperationException
+    {
+        private NestedStringBuilderCreationException()
+        {
+        }
+
+        internal protected NestedStringBuilderCreationException(string typeName, string extraMessage = "")
+            : base($"A nested call with `notNested: true`, or Either You forgot to call {typeName}.Dispose() of  in the past.{extraMessage}")
+        {
+        }
+
+        internal protected NestedStringBuilderCreationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+    }
+}

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -53,6 +53,16 @@ namespace Cysharp.Text
         /// <summary>Get the written buffer data.</summary>
         public ArraySegment<char> AsArraySegment() => new ArraySegment<char>(buffer, 0, index);
 
+        /// <summary>
+        /// Initializes a new instance
+        /// </summary>
+        /// <param name="disposeImmediately">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateStringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Utf16ValueStringBuilder(bool disposeImmediately)
         {

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
@@ -59,6 +59,16 @@ namespace Cysharp.Text
         /// <summary>Get the written buffer data.</summary>
         public ArraySegment<byte> AsArraySegment() => new ArraySegment<byte>(buffer, 0, index);
 
+        /// <summary>
+        /// Initializes a new instance
+        /// </summary>
+        /// <param name="disposeImmediately">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateUtf8StringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Utf8ValueStringBuilder(bool disposeImmediately)
         {

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
@@ -23,12 +23,26 @@ namespace Cysharp.Text
         }
 
         /// <summary>Create the Utf8(`Span[byte]`) StringBuilder.</summary>
+        /// <param name="notNested">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateUtf8StringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         public static Utf16ValueStringBuilder CreateStringBuilder(bool notNested)
         {
             return new Utf16ValueStringBuilder(notNested);
         }
 
         /// <summary>Create the Utf8(`Span[byte]`) StringBuilder, when true uses thread-static buffer that is faster but must return immediately.</summary>
+        /// <param name="notNested">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateUtf8StringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         public static Utf8ValueStringBuilder CreateUtf8StringBuilder(bool notNested)
         {
             return new Utf8ValueStringBuilder(notNested);

--- a/src/ZString/NestedStringBuilderCreationException.cs
+++ b/src/ZString/NestedStringBuilderCreationException.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace Cysharp.Text
+{
+    // Currently, this class is internals.
+    internal class NestedStringBuilderCreationException : InvalidOperationException
+    {
+        private NestedStringBuilderCreationException()
+        {
+        }
+
+        internal protected NestedStringBuilderCreationException(string typeName, string extraMessage = "")
+            : base($"A nested call with `notNested: true`, or Either You forgot to call {typeName}.Dispose() of  in the past.{extraMessage}")
+        {
+        }
+
+        internal protected NestedStringBuilderCreationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+
+    }
+}

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -53,6 +53,16 @@ namespace Cysharp.Text
         /// <summary>Get the written buffer data.</summary>
         public ArraySegment<char> AsArraySegment() => new ArraySegment<char>(buffer, 0, index);
 
+        /// <summary>
+        /// Initializes a new instance
+        /// </summary>
+        /// <param name="disposeImmediately">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateStringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Utf16ValueStringBuilder(bool disposeImmediately)
         {

--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -59,6 +59,16 @@ namespace Cysharp.Text
         /// <summary>Get the written buffer data.</summary>
         public ArraySegment<byte> AsArraySegment() => new ArraySegment<byte>(buffer, 0, index);
 
+        /// <summary>
+        /// Initializes a new instance
+        /// </summary>
+        /// <param name="disposeImmediately">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateUtf8StringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Utf8ValueStringBuilder(bool disposeImmediately)
         {

--- a/src/ZString/ZString.cs
+++ b/src/ZString/ZString.cs
@@ -23,12 +23,26 @@ namespace Cysharp.Text
         }
 
         /// <summary>Create the Utf8(`Span[byte]`) StringBuilder.</summary>
+        /// <param name="notNested">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateUtf8StringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         public static Utf16ValueStringBuilder CreateStringBuilder(bool notNested)
         {
             return new Utf16ValueStringBuilder(notNested);
         }
 
         /// <summary>Create the Utf8(`Span[byte]`) StringBuilder, when true uses thread-static buffer that is faster but must return immediately.</summary>
+        /// <param name="notNested">
+        /// If true uses thread-static buffer that is faster but must return immediately.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// This exception is thrown when <c>new StringBuilder(disposeImmediately: true)</c> or <c>ZString.CreateUtf8StringBuilder(notNested: true)</c> is nested.
+        /// See the README.md
+        /// </exception>
         public static Utf8ValueStringBuilder CreateUtf8StringBuilder(bool notNested)
         {
             return new Utf8ValueStringBuilder(notNested);

--- a/tests/ZString.Tests/NestedStringBuilder.cs
+++ b/tests/ZString.Tests/NestedStringBuilder.cs
@@ -1,0 +1,123 @@
+﻿using Cysharp.Text;
+using FluentAssertions;
+using FluentAssertions.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace ZStringTests
+{
+    public class NestedStringBuilder
+    {
+        [Fact]
+        public void NotNestedUtf16()
+        {
+            using (_ = ZString.CreateStringBuilder(true))
+            {
+            }
+            using (_ = ZString.CreateStringBuilder(false))
+            {
+                using (_ = ZString.CreateStringBuilder(true))
+                {
+                    using (_ = ZString.CreateStringBuilder(false))
+                    {
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void NestedUtf16()
+        {
+            using (_ = ZString.CreateStringBuilder(true))
+            {
+                using (_ = ZString.CreateStringBuilder(false))
+                {
+                    Assert.Throws<NestedStringBuilderCreationException>(() =>
+                    {
+                        using (_ = ZString.CreateStringBuilder(true))
+                        {
+                        }
+                    }
+                    );
+                }
+            }
+        }
+
+        [Fact]
+        public void NotDisposedUtf16()
+        {
+            {
+                _ = ZString.CreateStringBuilder(true);
+            }
+            {
+                Assert.Throws<NestedStringBuilderCreationException>(() =>
+                {
+                    using (_ = ZString.CreateStringBuilder(true))
+                    {
+                    }
+                }
+                );
+            }
+            Utf16ValueStringBuilder.scratchBufferUsed.IsSameOrEqualTo(true);
+            Utf16ValueStringBuilder.scratchBufferUsed = false;
+        }
+
+        [Fact]
+        public void NotNestedUtf8()
+        {
+            using (_ = ZString.CreateUtf8StringBuilder(true))
+            {
+            }
+            using (_ = ZString.CreateUtf8StringBuilder(false))
+            {
+                using (_ = ZString.CreateUtf8StringBuilder(true))
+                {
+                    using (_ = ZString.CreateUtf8StringBuilder(false))
+                    {
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void NestedUtf8()
+        {
+            using (_ = ZString.CreateUtf8StringBuilder(true))
+            {
+                using (_ = ZString.CreateUtf8StringBuilder(false))
+                {
+                    Assert.Throws<NestedStringBuilderCreationException>(() =>
+                    {
+                        using (_ = ZString.CreateUtf8StringBuilder(true))
+                        {
+                        }
+                    }
+                    );
+                }
+            }
+        }
+
+        [Fact]
+        public void NotDisposedUtf8()
+        {
+            {
+                _ = ZString.CreateUtf8StringBuilder(true);
+            }
+            {
+                Assert.Throws<NestedStringBuilderCreationException>(() =>
+                {
+                    using (_ = ZString.CreateUtf8StringBuilder(true))
+                    {
+                    }
+                }
+                );
+            }
+            Utf8ValueStringBuilder.scratchBufferUsed.IsSameOrEqualTo(true);
+            Utf8ValueStringBuilder.scratchBufferUsed = false;
+        }
+
+    }
+}


### PR DESCRIPTION
[As documented](https://github.com/Cysharp/ZString#advanced-tips), `notNested:true` should be used very carefully.

However, once you get it wrong, it is difficult to debug.

That's why I threw an `InvalidOperationException` (internally, `NestedStringBuilderCreationException`).

**This is a destructive change, but it only affects you when you use it incorrectly.**

## Impact on performance

Unfortunately, the benchmark will be slightly slower at the benchmark.
```
BenchmarkDotNet=v0.12.0, OS=Windows 10.0.19042
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.400-preview-015178
  [Host]   : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT
  ShortRun : .NET Core 3.1.5 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.27001), X64 RyuJIT

Job=ShortRun  IterationCount=1  LaunchCount=1
WarmupCount=1

|               Method |     Mean | Error |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------- |---------:|------:|-------:|------:|------:|----------:|
|     ZStringConcatInt | 41.44 ns |    NA | 0.0029 |     - |     - |      24 B |
|   NewZStrinConcatInt | 46.96 ns |    NA | 0.0029 |     - |     - |      24 B |
|    ZStringBuilderInt | 62.56 ns |    NA | 0.0029 |     - |     - |      24 B |
| NewZStringBuilderInt | 64.80 ns |    NA | 0.0029 |     - |     - |      24 B |
```

<details>

```diff
 sandbox/PerfBenchmark/PerfBenchmark.csproj | 5 ++++-
 1 file changed, 4 insertions(+), 1 deletion(-)

diff --git a/sandbox/PerfBenchmark/PerfBenchmark.csproj b/sandbox/PerfBenchmark/PerfBenchmark.csproj
index 6cb78ec..e76e48a 100644
--- a/sandbox/PerfBenchmark/PerfBenchmark.csproj
+++ b/sandbox/PerfBenchmark/PerfBenchmark.csproj
@@ -8,10 +8,13 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="StringFormatter" Version="1.0.0.13" />
+    <PackageReference Include="ZString" Version="2.1.3" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\ZString\ZString.csproj" />
+    <ProjectReference Include="..\..\src\ZString\ZString.csproj">
+      <Aliases>ZStringNew</Aliases>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>
```

```csharp
extern alias ZStringNew;
using BenchmarkDotNet.Attributes;
using Cysharp.Text;
using System;
using System.Collections.Generic;
using System.Text;

namespace PerfBenchmark.Benchmarks
{
    [Config(typeof(BenchmarkConfig))]
    public class VSStringFormatter
    {
        [Benchmark]
        public string ZStringConcatInt()
        {
            return ZString.Concat((int)1);
        }

        [Benchmark]
        public string NewZStrinConcatInt()
        {
            return ZStringNew::Cysharp.Text.ZString.Concat((int)1);
        }

        [Benchmark]
        public string ZStringBuilderInt()
        {
            using var builder = Cysharp.Text.ZString.CreateStringBuilder();
            builder.Append((int)1);
            return builder.ToString();
        }

        [Benchmark]
        public string NewZStringBuilderInt()
        {
            using var builder = ZStringNew::Cysharp.Text.ZString.CreateStringBuilder();
            builder.Append((int)1);
            return builder.ToString();
        }
    }
}
```
