### PR TITLE
Fix Utf8PreparedFormat

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Text;
 using System.Buffers;
 
@@ -45,13 +44,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -121,13 +120,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -212,13 +211,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -318,13 +317,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -439,13 +438,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -575,13 +574,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -726,13 +725,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -892,13 +891,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1073,13 +1072,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1269,13 +1268,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1480,13 +1479,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1706,13 +1705,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1947,13 +1946,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -2203,13 +2202,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -2474,13 +2473,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -2760,13 +2759,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -3027,7 +3026,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3043,7 +3041,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1)
@@ -3063,14 +3060,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3105,7 +3103,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3121,7 +3118,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2)
@@ -3141,14 +3137,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3198,7 +3195,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3214,7 +3210,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3)
@@ -3234,14 +3229,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3306,7 +3302,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3322,7 +3317,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
@@ -3342,14 +3336,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3429,7 +3424,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3445,7 +3439,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
@@ -3465,14 +3458,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3567,7 +3561,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3583,7 +3576,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
@@ -3603,14 +3595,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3720,7 +3713,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3736,7 +3728,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
@@ -3756,14 +3747,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3888,7 +3880,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3904,7 +3895,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
@@ -3924,14 +3914,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4071,7 +4062,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4087,7 +4077,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
@@ -4107,14 +4096,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4269,7 +4259,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4285,7 +4274,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
@@ -4305,14 +4293,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4482,7 +4471,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4498,7 +4486,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
@@ -4518,14 +4505,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4710,7 +4698,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4726,7 +4713,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
@@ -4746,14 +4732,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4953,7 +4940,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4969,7 +4955,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
@@ -4989,14 +4974,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -5211,7 +5197,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -5227,7 +5212,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
@@ -5247,14 +5231,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -5484,7 +5469,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -5500,7 +5484,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
@@ -5520,14 +5503,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -5772,7 +5756,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -5788,7 +5771,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
@@ -5808,14 +5790,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {

--- a/src/ZString/PreparedFormat.cs
+++ b/src/ZString/PreparedFormat.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 using System.Text;
 using System.Buffers;
 
@@ -45,13 +44,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -121,13 +120,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -212,13 +211,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -318,13 +317,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -439,13 +438,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -575,13 +574,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -726,13 +725,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -892,13 +891,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1073,13 +1072,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1269,13 +1268,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1480,13 +1479,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1706,13 +1705,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -1947,13 +1946,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -2203,13 +2202,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -2474,13 +2473,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -2760,13 +2759,13 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<char>
         {
-            var strSpan = FormatString.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
                 }
                 else
@@ -3027,7 +3026,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3043,7 +3041,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1)
@@ -3063,14 +3060,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3105,7 +3103,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3121,7 +3118,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2)
@@ -3141,14 +3137,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3198,7 +3195,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3214,7 +3210,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3)
@@ -3234,14 +3229,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3306,7 +3302,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3322,7 +3317,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4)
@@ -3342,14 +3336,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3429,7 +3424,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3445,7 +3439,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
@@ -3465,14 +3458,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3567,7 +3561,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3583,7 +3576,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
@@ -3603,14 +3595,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3720,7 +3713,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3736,7 +3728,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
@@ -3756,14 +3747,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -3888,7 +3880,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -3904,7 +3895,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
@@ -3924,14 +3914,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4071,7 +4062,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4087,7 +4077,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
@@ -4107,14 +4096,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4269,7 +4259,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4285,7 +4274,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
@@ -4305,14 +4293,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4482,7 +4471,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4498,7 +4486,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
@@ -4518,14 +4505,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4710,7 +4698,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4726,7 +4713,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
@@ -4746,14 +4732,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -4953,7 +4940,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -4969,7 +4955,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
@@ -4989,14 +4974,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -5211,7 +5197,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -5227,7 +5212,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
@@ -5247,14 +5231,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -5484,7 +5469,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -5500,7 +5484,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
@@ -5520,14 +5503,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {
@@ -5772,7 +5756,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-        readonly byte[] utf8Format;
 
         public Utf8PreparedFormat(string format)
         {
@@ -5788,7 +5771,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
         }
 
         public string Format(T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
@@ -5808,14 +5790,15 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var strSpan = utf8Format.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
-                    sb.Advance(item.Count);
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
                 }
                 else
                 {

--- a/src/ZString/PreparedFormat.tt
+++ b/src/ZString/PreparedFormat.tt
@@ -19,9 +19,6 @@ namespace Cysharp.Text
         public int MinSize { get; }
 
         readonly FormatSegment[] segments;
-<# if(!isUtf16) { #>
-        readonly byte[] utf8Format;
-<# } #>
 
         public <#= utf #>PreparedFormat(string format)
         {
@@ -37,9 +34,6 @@ namespace Cysharp.Text
                 }
             }
             this.MinSize = size;
-<# if(!isUtf16) { #>
-            this.utf8Format = Encoding.UTF8.GetBytes(format);
-<# } #>
         }
 
         public string Format(<#= CreateParameters(i) #>)
@@ -59,14 +53,21 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, <#= CreateParameters(i) #>)
             where TBufferWriter : IBufferWriter<<#= isUtf16 ? "char" : "byte" #>>
         {
-            var strSpan = <#= isUtf16 ? "FormatString" : "utf8Format" #>.AsSpan();
             foreach (var item in segments)
             {
                 if (!item.IsFormatArgument)
                 {
+                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+<# if(isUtf16) { #>
                     var span = sb.GetSpan(item.Count);
-                    strSpan.Slice(item.Offset, item.Count).TryCopyTo(span);
+                    strSpan.TryCopyTo(span);
                     sb.Advance(item.Count);
+<# } else { #>
+                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
+                    var span = sb.GetSpan(size);
+                    var count = Encoding.UTF8.GetBytes(strSpan, span);
+                    sb.Advance(count);
+<# } #>
                 }
                 else
                 {

--- a/tests/ZString.Tests/FormatTest.cs
+++ b/tests/ZString.Tests/FormatTest.cs
@@ -106,5 +106,11 @@ namespace ZStringTests
             var actual = ZString.Format(@"{0:h\,h\:mm\:ss}", span);
             actual.Should().Be(reference);
         }
+
+        [Fact]
+        public void Unicode()
+        {
+            Test("\u30cf\u30fc\u30c8: {0}, \u5bb6\u65cf: {1}(\u7d75\u6587\u5b57)", "\u2764", "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67");
+        }
     }
 }


### PR DESCRIPTION
Utf8PreparedFormat was broken when used with Unicode characters, so I fixed it.

### Test code
```csharp
        public void Unicode()
        {
            Test("\u30cf\u30fc\u30c8: {0}, \u5bb6\u65cf: {1}(\u7d75\u6587\u5b57)", "\u2764", "\uD83D\uDC69\u200D\uD83D\uDC69\u200D\uD83D\uDC67\u200D\uD83D\uDC67");
        }
```

Expected string to be 
`ハート: ❤, 家族: 👩‍👩‍👧‍👧(絵文字)`

### Results in ZString Ver.2.1.3
`ハ�❤�: {0}👩‍👩‍👧‍👧��族`