### PR TITLE
Improved compatibility of Format String

### DIFF
--- a/sandbox/BenchmarkVsReleasedVersion/BenchmarkVsReleasedVersion.csproj
+++ b/sandbox/BenchmarkVsReleasedVersion/BenchmarkVsReleasedVersion.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" Condition="$(TargetFramework) != 'netstandard3.1'" />
-      <PackageReference Include="ZString" Version="2.1.3" />
+      <PackageReference Include="ZString" Version="2.2.0" />
       <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
     </ItemGroup>
 

--- a/sandbox/BenchmarkVsReleasedVersion/BuiltinTypesBenchmark.cs
+++ b/sandbox/BenchmarkVsReleasedVersion/BuiltinTypesBenchmark.cs
@@ -96,16 +96,28 @@ namespace BenchmarkVsReleasedVersion
                 _byte, _dt, _dto, _decimal, _double, _guid, _short, _float, _ts, _uint, _ulong, _null, _string, _bool, _enum, _char);
         }
 
-        [BenchmarkCategory("CreatePreparedFormat"), Benchmark(Baseline = true)]
-        public object CreatePreparedFormat_()
+        [BenchmarkCategory("CreateUtf16PreparedFormat"), Benchmark(Baseline = true)]
+        public object CreateUtf16PreparedFormat_()
         {
             return new PF16(_format);
         }
 
-        [BenchmarkCategory("CreatePreparedFormat"), Benchmark]
-        public object CreatePreparedFormatN()
+        [BenchmarkCategory("CreateUtf16PreparedFormat"), Benchmark]
+        public object CreateUtf16PreparedFormatN()
         {
             return new NPF16(_format);
+        }
+
+        [BenchmarkCategory("CreateUtf8PreparedFormat"), Benchmark(Baseline = true)]
+        public object CreateUtf8PreparedFormat_()
+        {
+            return new PF8(_format);
+        }
+
+        [BenchmarkCategory("CreateUtf8PreparedFormat"), Benchmark]
+        public object CreateUtf8PreparedFormatN()
+        {
+            return new NPF8(_format);
         }
 
         [BenchmarkCategory("Utf16PreparedFormat"), Benchmark(Baseline = true)]

--- a/sandbox/BenchmarkVsReleasedVersion/FormatBenchmark.cs
+++ b/sandbox/BenchmarkVsReleasedVersion/FormatBenchmark.cs
@@ -61,16 +61,28 @@ namespace BenchmarkVsReleasedVersion
             return NZString.Format(FormatString, x, y);
         }
 
-        [BenchmarkCategory("CreatePreparedFormat"), Benchmark(Baseline = true)]
-        public object CreatePreparedFormat_()
+        [BenchmarkCategory("CreateUtf16PreparedFormat"), Benchmark(Baseline = true)]
+        public object CreateUtf16PreparedFormat_()
         {
             return new Utf16PreparedFormat<int, int>(FormatString);
         }
 
-        [BenchmarkCategory("CreatePreparedFormat"), Benchmark]
-        public object CreatePreparedFormatN()
+        [BenchmarkCategory("CreateUtf16PreparedFormat"), Benchmark]
+        public object CreateUtf16PreparedFormatN()
         {
             return new NewZString::Cysharp.Text.Utf16PreparedFormat<int, int>(FormatString);
+        }
+
+        [BenchmarkCategory("CreateUtf8PreparedFormat"), Benchmark(Baseline = true)]
+        public object CreateUtf8PreparedFormat_()
+        {
+            return new Utf8PreparedFormat<int, int>(FormatString);
+        }
+
+        [BenchmarkCategory("CreateUtf8PreparedFormat"), Benchmark]
+        public object CreateUtf8PreparedFormatN()
+        {
+            return new NewZString::Cysharp.Text.Utf8PreparedFormat<int, int>(FormatString);
         }
 
         [BenchmarkCategory("Utf16PreparedFormat"), Benchmark(Baseline = true)]

--- a/sandbox/PerfBenchmark/Benchmarks/FormatBenchmark.cs
+++ b/sandbox/PerfBenchmark/Benchmarks/FormatBenchmark.cs
@@ -14,6 +14,7 @@ namespace PerfBenchmark.Benchmarks
         int y;
         string format;
         StringBuilder stringBuilder;
+        Utf16PreparedFormat<int, int> preparedFormat;
 
         public FormatBenchmark()
         {
@@ -21,9 +22,10 @@ namespace PerfBenchmark.Benchmarks
             y = int.Parse("200");
             format = "x:{0}, y:{1}";
             stringBuilder = new StringBuilder();
+            preparedFormat = new Utf16PreparedFormat<int,int>(format);
         }
 
-        [Benchmark]
+        [Benchmark(Baseline = true)]
         public string StringFormat()
         {
             return string.Format(format, x, y);
@@ -33,6 +35,12 @@ namespace PerfBenchmark.Benchmarks
         public string ZStringFormat()
         {
             return ZString.Format(format, x, y);
+        }
+
+        [Benchmark]
+        public string ZStringPreparedFormat()
+        {
+            return preparedFormat.Format(x, y);
         }
 
         [Benchmark]

--- a/sandbox/PerfBenchmark/Benchmarks/SixObjectConcatBenchmark.cs
+++ b/sandbox/PerfBenchmark/Benchmarks/SixObjectConcatBenchmark.cs
@@ -19,7 +19,7 @@ namespace PerfBenchmark.Benchmarks
             z = int.Parse("555");
         }
 
-        [Benchmark]
+        [Benchmark(Baseline = true)]
         public string StringPlus()
         {
             return "x:" + x + " y:" + y + " z:" + z;

--- a/src/ZString.Unity/Assets/Scripts/ZString/ExceptionUtil.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ExceptionUtil.cs
@@ -15,5 +15,10 @@ namespace Cysharp.Text
         {
             throw new FormatException("Index (zero based) must be greater than or equal to zero and less than the size of the argument list.");
         }
+
+        internal static void ThrowFormatError()
+        {
+            throw new FormatException("Input string was not in a correct format.");
+        }
     }
 }

--- a/src/ZString.Unity/Assets/Scripts/ZString/FormatHelper.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/FormatHelper.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Text;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Text
+{
+    internal static partial class Utf16PreparedFormat
+    {
+        public static void FormatTo<TBufferWriter, T>(ref TBufferWriter sb, in FormatSegment item, T arg, string argName)
+            where TBufferWriter : IBufferWriter<char>
+        {
+            const char sp = (char)' ';
+            var width = item.Alignment;
+            var format = item.FormatString.AsSpan(item.Offset, item.Count);
+
+            if (width <= 0) // leftJustify
+            {
+                width *= -1;
+
+                var span = sb.GetSpan(0);
+                if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out var argWritten, format))
+                {
+                    sb.Advance(0);
+                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
+                    if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out argWritten, format))
+                    {
+                        ExceptionUtil.ThrowArgumentException(argName);
+                    }
+                }
+                sb.Advance(argWritten);
+
+                int padding = width - argWritten;
+                if (width > 0 && padding > 0)
+                {
+                    var paddingSpan = sb.GetSpan(padding);
+                    paddingSpan.Fill(sp);
+                    sb.Advance(padding);
+                }
+            }
+            else // rightJustify
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    var s = Unsafe.As<string>(arg);
+                    int padding = width - s.Length;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    var span = sb.GetSpan(s.Length);
+                    s.AsSpan().CopyTo(span);
+                    sb.Advance(s.Length);
+                }
+                else
+                {
+                    Span<char> s = stackalloc char[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
+
+                    if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
+                    {
+                        s = stackalloc char[s.Length * 2];
+                        if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
+                        {
+                            ExceptionUtil.ThrowArgumentException(argName);
+                        }
+                    }
+
+                    int padding = width - charsWritten;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    var span = sb.GetSpan(charsWritten);
+                    s.CopyTo(span);
+                    sb.Advance(charsWritten);
+                }
+            }
+        }
+    }
+    internal static partial class Utf8PreparedFormat
+    {
+        public static void FormatTo<TBufferWriter, T>(ref TBufferWriter sb, in FormatSegment item, T arg, string argName)
+            where TBufferWriter : IBufferWriter<byte>
+        {
+            const byte sp = (byte)' ';
+            var width = item.Alignment;
+            var format = item.StandardFormat;
+
+            if (width <= 0) // leftJustify
+            {
+                width *= -1;
+
+                var span = sb.GetSpan(0);
+                if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out var argWritten, format))
+                {
+                    sb.Advance(0);
+                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
+                    if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out argWritten, format))
+                    {
+                        ExceptionUtil.ThrowArgumentException(argName);
+                    }
+                }
+                sb.Advance(argWritten);
+
+                int padding = width - argWritten;
+                if (width > 0 && padding > 0)
+                {
+                    var paddingSpan = sb.GetSpan(padding);
+                    paddingSpan.Fill(sp);
+                    sb.Advance(padding);
+                }
+            }
+            else // rightJustify
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    var s = Unsafe.As<string>(arg);
+                    int padding = width - s.Length;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    ZString.AppendChars(ref sb, s.AsSpan());
+                }
+                else
+                {
+                    Span<byte> s = stackalloc byte[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
+
+                    if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
+                    {
+                        s = stackalloc byte[s.Length * 2];
+                        if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
+                        {
+                            ExceptionUtil.ThrowArgumentException(argName);
+                        }
+                    }
+
+                    int padding = width - charsWritten;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    var span = sb.GetSpan(charsWritten);
+                    s.CopyTo(span);
+                    sb.Advance(charsWritten);
+                }
+            }
+        }
+    }
+}

--- a/src/ZString.Unity/Assets/Scripts/ZString/FormatParser.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/FormatParser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
@@ -11,45 +12,207 @@ namespace Cysharp.Text
             public readonly int Index;
             public readonly ReadOnlySpan<char> FormatString;
             public readonly int LastIndex;
+            public readonly int Alignment;
 
-            public ParseResult(int index, ReadOnlySpan<char> formatString, int lastIndex)
+            public ParseResult(int index, ReadOnlySpan<char> formatString, int lastIndex, int alignment)
             {
                 Index = index;
                 FormatString = formatString;
                 LastIndex = lastIndex;
+                Alignment = alignment;
             }
         }
 
-        public static ParseResult Parse(ReadOnlySpan<char> format)
+        internal const int ArgLengthLimit = 16;
+        internal const int WidthLimit = 1000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParserScanResult ScanFormatString(ReadOnlySpan<char> format, ref int i)
         {
-            int index = -1;
-            var formatStart = -1;
+            var len = format.Length;
+            char c = format[i];
 
-            // ignore start '{'
-            for (int i = 1; i < format.Length; i++)
+            i++; // points netxt char
+            if (c == '}')
             {
-                if (format[i] == '}')
+                // skip escaped '}'
+                if (i < len && format[i] == '}')
                 {
-                    if (index == -1)
-                    {
-                        index = Int32.Parse(format.Slice(1, i - 1));
-                        return new ParseResult(index, default, i);
-                    }
-                    else
-                    {
-                        var formatString = format.Slice(formatStart, i - formatStart);
-                        return new ParseResult(index, formatString, i);
-                    }
+                    i++;
+                    return ParserScanResult.EscapedChar;
                 }
-
-                if (index == -1 && (format[i] == ',' && format[i - 1] != '\\') || (format[i] == ':' && format[i - 1] != '\\'))
+                else
                 {
-                    index = Int32.Parse(format.Slice(1, i - 1));
-                    formatStart = i + 1;
+                    ExceptionUtil.ThrowFormatError();
+                    return ParserScanResult.NormalChar; // NOTE Don't reached
                 }
             }
+            else if (c == '{')
+            {
+                // skip escaped '{'
+                if (i < len && format[i] == '{')
+                {
+                    i++;
+                    return ParserScanResult.EscapedChar;
+                }
+                else
+                {
+                    i--;
+                    return ParserScanResult.BraceOpen;
+                }
+            }
+            else
+            {
+                // ch is the normal char OR end of text
+                return ParserScanResult.NormalChar;
+            }
+        }
 
-            throw new FormatException("Invalid format string. format:" + format.ToString());
+        // Accept only non-unicode numbers
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsDigit(char c) => '0' <= c && c <= '9';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParseResult Parse(string format, int i)
+        {
+            char c = default;
+            var len = format.Length;
+
+            i++; // Skip `{`
+
+            //  === Index Component ===
+            //   ('0'-'9')+ WS*
+
+            if (i == len || !IsDigit(c = format[i]))
+            {
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            int paramIndex = 0;
+            do
+            {
+                paramIndex = (paramIndex * 10) + c - '0';
+
+                if (++i == len)
+                    ExceptionUtil.ThrowFormatError();
+
+                c = format[i];
+            }
+            while (IsDigit(c) && paramIndex < ArgLengthLimit);
+
+            if (paramIndex >= ArgLengthLimit)
+            {
+                ExceptionUtil.ThrowFormatException();
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Alignment Component ===
+            //   comma WS* minus? ('0'-'9')+ WS*
+
+            int alignment = 0;
+
+            if (c == ',')
+            {
+                i++;
+
+                // skip whitespace.
+                while (i < len && (c = format[i]) == ' ')
+                    i++;
+
+                if (i == len)
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                var leftJustify = false;
+                if (c == '-')
+                {
+                    leftJustify = true;
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+
+                if (!IsDigit(c))
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                do
+                {
+                    alignment = (alignment * 10) + c - '0';
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+                while (IsDigit(c) && alignment < WidthLimit);
+
+                if (leftJustify)
+                    alignment *= -1;
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Format String Component ===
+
+            ReadOnlySpan<char> itemFormatSpan = default;
+
+            if (c == ':')
+            {
+                i++;
+                int formatStart = i;
+
+                while (true)
+                {
+                    if (i == len)
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+                    c = format[i];
+
+                    if (c == '}')
+                    {
+                        break;
+                    }
+                    else if (c == '{')
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+
+                    i++;
+                }
+
+                // has format
+                if (i > formatStart)
+                {
+                    itemFormatSpan = format.AsSpan(formatStart, i - formatStart);
+                }
+            }
+            else if (c != '}')
+            {
+                // Unexpected character
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            i++; // Skip `}`
+            return new ParseResult(paramIndex, itemFormatSpan, i, alignment);
         }
     }
+    internal enum ParserScanResult
+    {
+        BraceOpen,
+        EscapedChar,
+        NormalChar,
+    }
+
 }

--- a/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
@@ -9,12 +9,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -50,7 +50,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -74,12 +74,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -115,7 +115,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -144,12 +144,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -185,7 +185,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -219,12 +219,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -260,7 +260,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -299,12 +299,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -340,7 +340,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -384,12 +384,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -425,7 +425,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -474,12 +474,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -515,7 +515,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -569,12 +569,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -610,7 +610,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -669,12 +669,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -710,7 +710,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -774,12 +774,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -815,7 +815,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -884,12 +884,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -925,7 +925,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -999,12 +999,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1040,7 +1040,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1119,12 +1119,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1160,7 +1160,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1244,12 +1244,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1285,7 +1285,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1374,12 +1374,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1415,7 +1415,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1509,12 +1509,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1550,7 +1550,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1649,12 +1649,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1684,19 +1685,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1715,12 +1715,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1750,19 +1751,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1786,12 +1786,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1821,19 +1822,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1862,12 +1862,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1897,19 +1898,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1943,12 +1943,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1978,19 +1979,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2029,12 +2029,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2064,19 +2065,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2120,12 +2120,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2155,19 +2156,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2216,12 +2216,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2251,19 +2252,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2317,12 +2317,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2352,19 +2353,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2423,12 +2423,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2458,19 +2459,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2534,12 +2534,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2569,19 +2570,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2650,12 +2650,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2685,19 +2686,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2771,12 +2771,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2806,19 +2807,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2897,12 +2897,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2932,19 +2933,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -3028,12 +3028,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -3063,19 +3064,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -3164,12 +3164,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -3199,19 +3200,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:

--- a/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
@@ -44,23 +44,27 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
-                        }
-                        break;
-                    case 0:
-                        {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
                         }
+                    case 0:
+                        {
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
+                            break;
+                        }
+                    default:
+                        break;
                 }
             }
         }
@@ -105,28 +109,32 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -171,33 +179,37 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -242,38 +254,42 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -318,43 +334,47 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -399,48 +419,52 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -485,53 +509,57 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -576,58 +604,62 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -672,63 +704,67 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -773,68 +809,72 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -879,73 +919,77 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -990,78 +1034,82 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1106,83 +1154,87 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1227,88 +1279,92 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf16FormatHelper.FormatTo(ref sb, arg14, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg14));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1353,93 +1409,97 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf16FormatHelper.FormatTo(ref sb, arg14, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf16FormatHelper.FormatTo(ref sb, arg15, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg15));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1484,98 +1544,102 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf16FormatHelper.FormatTo(ref sb, arg14, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf16FormatHelper.FormatTo(ref sb, arg15, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg15));
                             break;
                         }
                     case 15:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            Utf16FormatHelper.FormatTo(ref sb, arg16, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg16));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1620,24 +1684,28 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
-                        }
-                        break;
-                    case 0:
-                        {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
                         }
+                    case 0:
+                        {
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
+                            break;
+                        }
+                    default:
+                        break;
                 }
             }
         }
@@ -1682,29 +1750,33 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1749,34 +1821,38 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1821,39 +1897,43 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1898,44 +1978,48 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1980,49 +2064,53 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2067,54 +2155,58 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2159,59 +2251,63 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2256,64 +2352,68 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2358,69 +2458,73 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2465,74 +2569,78 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2577,79 +2685,83 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2694,84 +2806,88 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2816,89 +2932,93 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref sb, arg14, item.Alignment, item.StandardFormat, nameof(arg14));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2943,94 +3063,98 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref sb, arg14, item.Alignment, item.StandardFormat, nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref sb, arg15, item.Alignment, item.StandardFormat, nameof(arg15));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -3075,99 +3199,103 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref sb, arg14, item.Alignment, item.StandardFormat, nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref sb, arg15, item.Alignment, item.StandardFormat, nameof(arg15));
                             break;
                         }
                     case 15:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            Utf8FormatHelper.FormatTo(ref sb, arg16, item.Alignment, item.StandardFormat, nameof(arg16));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }

--- a/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormat.cs
@@ -46,40 +46,25 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
@@ -122,55 +107,30 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
@@ -213,70 +173,35 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
@@ -319,85 +244,40 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
@@ -440,100 +320,45 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
@@ -576,115 +401,50 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
@@ -727,130 +487,55 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
@@ -893,145 +578,60 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
@@ -1074,160 +674,65 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
@@ -1270,175 +775,70 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
@@ -1481,190 +881,75 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
@@ -1707,205 +992,80 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
@@ -1948,220 +1108,85 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
@@ -2204,235 +1229,90 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
@@ -2475,250 +1355,95 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
@@ -2761,265 +1486,100 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 15:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg16));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
+                    case 15:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1>
     {
         public string FormatString { get; }
@@ -3062,41 +1622,26 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
@@ -3139,56 +1684,31 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
@@ -3231,71 +1751,36 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
@@ -3338,86 +1823,41 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
@@ -3460,101 +1900,46 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
@@ -3597,116 +1982,51 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
@@ -3749,131 +2069,56 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
@@ -3916,146 +2161,61 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
@@ -4098,161 +2258,66 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
@@ -4295,176 +2360,71 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
@@ -4507,191 +2467,76 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
@@ -4734,206 +2579,81 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
@@ -4976,221 +2696,86 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
@@ -5233,236 +2818,91 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
@@ -5505,251 +2945,96 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
@@ -5792,264 +3077,99 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 15:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg16));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
+                    case 15:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            break;
+                        }
                 }
             }
         }
     }
-
 }

--- a/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormatHelper.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormatHelper.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Text;
 
 namespace Cysharp.Text
 {
     internal static class PreparedFormatHelper
     {
-        internal static FormatSegment[] Parse(string format, bool withStandardFormat)
+        internal static Utf16FormatSegment[] Utf16Parse(string format)
         {
             if (format == null)
             {
                 throw new ArgumentNullException(nameof(format));
             }
 
-            var list = new List<FormatSegment>();
+            var list = new List<Utf16FormatSegment>();
 
             int i = 0;
             int len = format.Length;
@@ -42,7 +42,7 @@ namespace Cysharp.Text
 
                     if (size != 0)
                     {
-                        list.Add(new FormatSegment(copyFrom, size, FormatSegment.NotFormatIndex, format, default, 0));
+                        list.Add(new Utf16FormatSegment(copyFrom, size, Utf16FormatSegment.NotFormatIndex, 0));
                     }
 
                     copyFrom = i;
@@ -63,46 +63,117 @@ namespace Cysharp.Text
                 copyFrom = indexParse.LastIndex; // continue after '}'
                 i = indexParse.LastIndex;
 
-                list.Add(new FormatSegment(indexParse.LastIndex - indexParse.FormatString.Length - 1, indexParse.FormatString.Length, indexParse.Index, format, withStandardFormat, indexParse.Alignment));
+                list.Add(new Utf16FormatSegment(indexParse.LastIndex - indexParse.FormatString.Length - 1, indexParse.FormatString.Length, indexParse.Index, indexParse.Alignment));
+            }
 
+            return list.ToArray();
+        }
+
+        internal static Utf8FormatSegment[] Utf8Parse(string format, out byte[] utf8buffer)
+        {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            var list = new List<Utf8FormatSegment>();
+            utf8buffer = new byte[Encoding.UTF8.GetMaxByteCount(format.Length)];
+            var bufOffset = 0;
+
+            int i = 0;
+            int len = format.Length;
+
+            var copyFrom = 0;
+            var formatSpan = format.AsSpan();
+
+            while (true)
+            {
+                while (i < len)
+                {
+                    var parserScanResult = FormatParser.ScanFormatString(formatSpan, ref i);
+
+                    if (ParserScanResult.NormalChar == parserScanResult && i < len)
+                    {
+                        // skip normal char
+                        continue;
+                    }
+
+                    var size = i - copyFrom;
+                    if (ParserScanResult.EscapedChar == parserScanResult)
+                    {
+                        size--;
+                    }
+
+                    if (size != 0)
+                    {
+                        var utf8size = Encoding.UTF8.GetBytes(format, copyFrom, size, utf8buffer, bufOffset);
+                        list.Add(new Utf8FormatSegment(bufOffset, utf8size, Utf8FormatSegment.NotFormatIndex, default, 0));
+                        bufOffset += utf8size;
+                    }
+
+                    copyFrom = i;
+
+                    if (ParserScanResult.BraceOpen == parserScanResult)
+                    {
+                        break;
+                    }
+                }
+
+                if (i >= len)
+                {
+                    break;
+                }
+
+                // Here it is before `{`.
+                var indexParse = FormatParser.Parse(format, i);
+                copyFrom = indexParse.LastIndex; // continue after '}'
+                i = indexParse.LastIndex;
+                list.Add(new Utf8FormatSegment(0, 0, indexParse.Index, StandardFormat.Parse(indexParse.FormatString), indexParse.Alignment));
             }
 
             return list.ToArray();
         }
     }
 
-    internal readonly struct FormatSegment
+    internal readonly struct Utf8FormatSegment
     {
         public const int NotFormatIndex = -1;
 
-        //public readonly bool IsFormatArgument;
-        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
-
         public readonly int Offset;
         public readonly int Count;
-        public readonly int Alignment;
         public readonly int FormatIndex;
-        public readonly string FormatString;
-
-        // Utf8
         public readonly StandardFormat StandardFormat;
+        public readonly int Alignment;
 
-        public FormatSegment(int offset, int count, int formatIndex, string formatString, bool utf8, int alignment)
+        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+
+        public Utf8FormatSegment(int offset, int count, int formatIndex, StandardFormat format, int alignment)
         {
             Offset = offset;
             Count = count;
-            //IsFormatArgument = formatIndex != NotFormatIndex;
             FormatIndex = formatIndex;
-            FormatString = formatString;
+            StandardFormat = format;
             Alignment = alignment;
-            if (utf8)
-            {
-                StandardFormat = (formatString != null) ? StandardFormat.Parse(formatString.AsSpan(Offset, Count)) : default;
-            }
-            else
-            {
-                StandardFormat = default;
-            }
+        }
+    }
+
+    internal readonly struct Utf16FormatSegment
+    {
+        public const int NotFormatIndex = -1;
+
+        public readonly int Offset;
+        public readonly int Count;
+        public readonly int FormatIndex;
+        public readonly int Alignment;
+
+        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+
+        public Utf16FormatSegment(int offset, int count, int formatIndex, int alignment)
+        {
+            Offset = offset;
+            Count = count;
+            FormatIndex = formatIndex;
+            Alignment = alignment;
         }
     }
 }

--- a/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormatHelper.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormatHelper.cs
@@ -75,12 +75,14 @@ namespace Cysharp.Text
     {
         public const int NotFormatIndex = -1;
 
+        //public readonly bool IsFormatArgument;
+        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+
         public readonly int Offset;
         public readonly int Count;
-        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+        public readonly int Alignment;
         public readonly int FormatIndex;
         public readonly string FormatString;
-        public readonly int Alignment;
 
         // Utf8
         public readonly StandardFormat StandardFormat;
@@ -89,6 +91,7 @@ namespace Cysharp.Text
         {
             Offset = offset;
             Count = count;
+            //IsFormatArgument = formatIndex != NotFormatIndex;
             FormatIndex = formatIndex;
             FormatString = formatString;
             Alignment = alignment;

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -7,10 +7,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -33,28 +39,32 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -68,14 +78,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2>(string format, T1 arg1, T2 arg2)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -98,31 +113,35 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -136,14 +155,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -166,34 +190,38 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -207,14 +235,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -237,37 +270,41 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -281,14 +318,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -311,40 +353,44 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -358,14 +404,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -388,43 +439,47 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -438,14 +493,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -468,46 +528,50 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -521,14 +585,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -551,49 +620,53 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -607,14 +680,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -637,52 +715,56 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -696,14 +778,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -726,55 +813,59 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -788,14 +879,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -818,58 +914,62 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -883,14 +983,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -913,61 +1018,65 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -981,14 +1090,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1011,64 +1125,68 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1082,14 +1200,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1112,67 +1235,71 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, indexParse.FormatString, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1186,14 +1313,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1216,70 +1348,74 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, indexParse.FormatString, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, indexParse.FormatString, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1293,14 +1429,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1323,73 +1464,77 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, indexParse.FormatString, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, indexParse.FormatString, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
                             continue;
                         case 15:
-                            AppendFormatInternal(arg16, indexParse.FormatString, nameof(arg16));
+                            AppendFormatInternal(arg16, indexParse.Alignment, indexParse.FormatString, nameof(arg16));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1403,6 +1548,5 @@ namespace Cysharp.Text
                 }
             }
         }
-
     }
 }

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
@@ -8,10 +8,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -34,28 +40,33 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -74,10 +85,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2>(string format, T1 arg1, T2 arg2)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -100,31 +117,36 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -143,10 +165,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -169,34 +197,39 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -215,10 +248,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -241,37 +280,42 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -290,10 +334,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -316,40 +366,45 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -368,10 +423,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -394,43 +455,48 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -449,10 +515,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -475,46 +547,51 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -533,10 +610,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -559,49 +642,54 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -620,10 +708,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -646,52 +740,57 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -710,10 +809,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -736,55 +841,60 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -803,10 +913,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -829,58 +945,63 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -899,10 +1020,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -925,61 +1052,66 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -998,10 +1130,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1024,64 +1162,69 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -1100,10 +1243,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1126,67 +1275,72 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, writeFormat, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -1205,10 +1359,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1231,70 +1391,75 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, writeFormat, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, writeFormat, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -1313,10 +1478,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1339,73 +1510,78 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, writeFormat, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, writeFormat, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         case 15:
-                            AppendFormatInternal(arg16, writeFormat, nameof(arg16));
+                            AppendFormatInternal(arg16, indexParse.Alignment, writeFormat, nameof(arg16));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
@@ -13,7 +13,7 @@ namespace Cysharp.Text
 
         const int ThreadStaticBufferSize = 64444;
         const int DefaultBufferSize = 65536; // use 64K default buffer.
-        internal static readonly Encoding UTF8NoBom = new UTF8Encoding(false);
+        static Encoding UTF8NoBom = new UTF8Encoding(false);
 
         static byte newLine1;
         static byte newLine2;

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.Utf8Format.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.Utf8Format.cs
@@ -54,7 +54,7 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -93,7 +93,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2)
         {
@@ -140,10 +139,10 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -182,7 +181,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3)
         {
@@ -229,13 +227,13 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -274,7 +272,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
@@ -321,16 +318,16 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -369,7 +366,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
@@ -416,19 +412,19 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -467,7 +463,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
@@ -514,22 +509,22 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -568,7 +563,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
@@ -615,25 +609,25 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -672,7 +666,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
@@ -719,28 +712,28 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -779,7 +772,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
@@ -826,31 +818,31 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -889,7 +881,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
@@ -936,34 +927,34 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1002,7 +993,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
@@ -1049,37 +1039,37 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1118,7 +1108,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
@@ -1165,40 +1154,40 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1237,7 +1226,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
@@ -1284,43 +1272,43 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1359,7 +1347,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
@@ -1406,46 +1393,46 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            Utf8FormatInternal(bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1484,7 +1471,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
@@ -1531,49 +1517,49 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            Utf8FormatInternal(bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            Utf8FormatInternal(bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1612,7 +1598,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
@@ -1659,52 +1644,52 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            Utf8FormatInternal(bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            Utf8FormatInternal(bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         case 15:
-                            Utf8FormatInternal(bufferWriter, arg16, indexParse.Alignment, writeFormat, nameof(arg16));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg16, indexParse.Alignment, writeFormat, nameof(arg16));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1743,78 +1728,5 @@ namespace Cysharp.Text
                 }
             }
         }
-
-
-        static void Utf8FormatInternal<T>(IBufferWriter<byte> bufferWriter, T arg, int width, StandardFormat format, string argName)
-        {
-            if (width <= 0) // leftJustify
-            {
-                width *= -1;
-
-                var buffer = bufferWriter.GetSpan();
-
-                if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out var written, format))
-                {
-                    bufferWriter.Advance(0);
-                    buffer = bufferWriter.GetSpan(Math.Max(buffer.Length + 1, written));
-
-                    if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out written, format))
-                    {
-                        ExceptionUtil.ThrowArgumentException(argName);
-                    }
-                }
-
-                bufferWriter.Advance(written);
-
-                int padding = width - written;
-                if (width > 0 && padding > 0)
-                {
-                    // TODO Append(' ', padding);
-                    bufferWriter.GetSpan(padding).Fill((byte)' ');  // TODO Fill Method is too slow.
-                    bufferWriter.Advance(padding);
-                }
-            }
-            else // rightJustify
-            {
-                if (typeof(T) == typeof(string))
-                {
-                    var s = Unsafe.As<string>(arg);
-                    int padding = width - s.Length;
-                    if (padding > 0)
-                    {
-                        // TODO Append(' ', padding);
-                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
-                        bufferWriter.Advance(padding);
-                    }
-
-                    ZString.AppendChars(ref bufferWriter, s.AsSpan());
-                }
-                else
-                {
-                    Span<byte> s = stackalloc byte[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
-
-                    if (!FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
-                    {
-                        s = stackalloc byte[s.Length * 2];
-                        if (!FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
-                        {
-                            ExceptionUtil.ThrowArgumentException(argName);
-                        }
-                    }
-
-                    int padding = width - charsWritten;
-                    if (padding > 0)
-                    {
-                        // TODO Append(' ', padding);
-                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
-                        bufferWriter.Advance(padding);
-                    }
-
-                    s.CopyTo(bufferWriter.GetSpan(charsWritten));
-                    bufferWriter.Advance(charsWritten);
-                }
-            }
-        }
-    
     }
 }

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.cs
@@ -11,6 +11,14 @@ namespace Cysharp.Text
     {
         static Encoding UTF8NoBom = new UTF8Encoding(false);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AppendChars<TBufferWriter>(ref TBufferWriter sb, ReadOnlySpan<char> chars)
+            where TBufferWriter : System.Buffers.IBufferWriter<byte>
+        {
+            var span = sb.GetSpan(UTF8NoBom.GetMaxByteCount(chars.Length));
+            sb.Advance(UTF8NoBom.GetBytes(chars, span));
+        }
+
         /// <summary>Create the Utf16 string StringBuilder.</summary>
         public static Utf16ValueStringBuilder CreateStringBuilder()
         {

--- a/src/ZString/ExceptionUtil.cs
+++ b/src/ZString/ExceptionUtil.cs
@@ -15,5 +15,10 @@ namespace Cysharp.Text
         {
             throw new FormatException("Index (zero based) must be greater than or equal to zero and less than the size of the argument list.");
         }
+
+        internal static void ThrowFormatError()
+        {
+            throw new FormatException("Input string was not in a correct format.");
+        }
     }
 }

--- a/src/ZString/FormatHelper.cs
+++ b/src/ZString/FormatHelper.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Text;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Text
+{
+    internal static partial class Utf16PreparedFormat
+    {
+        public static void FormatTo<TBufferWriter, T>(ref TBufferWriter sb, in FormatSegment item, T arg, string argName)
+            where TBufferWriter : IBufferWriter<char>
+        {
+            const char sp = (char)' ';
+            var width = item.Alignment;
+            var format = item.FormatString.AsSpan(item.Offset, item.Count);
+
+            if (width <= 0) // leftJustify
+            {
+                width *= -1;
+
+                var span = sb.GetSpan(0);
+                if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out var argWritten, format))
+                {
+                    sb.Advance(0);
+                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
+                    if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out argWritten, format))
+                    {
+                        ExceptionUtil.ThrowArgumentException(argName);
+                    }
+                }
+                sb.Advance(argWritten);
+
+                int padding = width - argWritten;
+                if (width > 0 && padding > 0)
+                {
+                    var paddingSpan = sb.GetSpan(padding);
+                    paddingSpan.Fill(sp);
+                    sb.Advance(padding);
+                }
+            }
+            else // rightJustify
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    var s = Unsafe.As<string>(arg);
+                    int padding = width - s.Length;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    var span = sb.GetSpan(s.Length);
+                    s.AsSpan().CopyTo(span);
+                    sb.Advance(s.Length);
+                }
+                else
+                {
+                    Span<char> s = stackalloc char[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
+
+                    if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
+                    {
+                        s = stackalloc char[s.Length * 2];
+                        if (!Utf16ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
+                        {
+                            ExceptionUtil.ThrowArgumentException(argName);
+                        }
+                    }
+
+                    int padding = width - charsWritten;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    var span = sb.GetSpan(charsWritten);
+                    s.CopyTo(span);
+                    sb.Advance(charsWritten);
+                }
+            }
+        }
+    }
+    internal static partial class Utf8PreparedFormat
+    {
+        public static void FormatTo<TBufferWriter, T>(ref TBufferWriter sb, in FormatSegment item, T arg, string argName)
+            where TBufferWriter : IBufferWriter<byte>
+        {
+            const byte sp = (byte)' ';
+            var width = item.Alignment;
+            var format = item.StandardFormat;
+
+            if (width <= 0) // leftJustify
+            {
+                width *= -1;
+
+                var span = sb.GetSpan(0);
+                if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out var argWritten, format))
+                {
+                    sb.Advance(0);
+                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
+                    if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out argWritten, format))
+                    {
+                        ExceptionUtil.ThrowArgumentException(argName);
+                    }
+                }
+                sb.Advance(argWritten);
+
+                int padding = width - argWritten;
+                if (width > 0 && padding > 0)
+                {
+                    var paddingSpan = sb.GetSpan(padding);
+                    paddingSpan.Fill(sp);
+                    sb.Advance(padding);
+                }
+            }
+            else // rightJustify
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    var s = Unsafe.As<string>(arg);
+                    int padding = width - s.Length;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    ZString.AppendChars(ref sb, s.AsSpan());
+                }
+                else
+                {
+                    Span<byte> s = stackalloc byte[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
+
+                    if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
+                    {
+                        s = stackalloc byte[s.Length * 2];
+                        if (!Utf8ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
+                        {
+                            ExceptionUtil.ThrowArgumentException(argName);
+                        }
+                    }
+
+                    int padding = width - charsWritten;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    var span = sb.GetSpan(charsWritten);
+                    s.CopyTo(span);
+                    sb.Advance(charsWritten);
+                }
+            }
+        }
+    }
+}

--- a/src/ZString/FormatHelper.tt
+++ b/src/ZString/FormatHelper.tt
@@ -13,19 +13,16 @@ using System.Runtime.CompilerServices;
 namespace Cysharp.Text
 {
 <# foreach(var utf in utfTypes ) { var isUtf16 = (utf == "Utf16"); var elemType = isUtf16 ? "char" : "byte"; #>
-    internal static partial class <#= utf #>PreparedFormat
+    internal static partial class <#= utf #>FormatHelper
     {
-        public static void FormatTo<TBufferWriter, T>(ref TBufferWriter sb, in FormatSegment item, T arg, string argName)
+        const <#= elemType #> sp = (<#= elemType #>)' ';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void FormatTo<TBufferWriter, T>(ref TBufferWriter sb, T arg, int width, <#= isUtf16 ? "ReadOnlySpan<char>" : "StandardFormat" #> format, string argName)
             where TBufferWriter : IBufferWriter<<#= elemType #>>
         {
-            const <#= elemType #> sp = (<#= elemType #>)' ';
-            var width = item.Alignment;
-            var format = <#= isUtf16 ? "item.FormatString.AsSpan(item.Offset, item.Count)" : "item.StandardFormat" #>;
-
             if (width <= 0) // leftJustify
             {
-                width *= -1;
-
                 var span = sb.GetSpan(0);
                 if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out var argWritten, format))
                 {
@@ -38,6 +35,7 @@ namespace Cysharp.Text
                 }
                 sb.Advance(argWritten);
 
+                width *= -1;
                 int padding = width - argWritten;
                 if (width > 0 && padding > 0)
                 {
@@ -46,54 +44,61 @@ namespace Cysharp.Text
                     sb.Advance(padding);
                 }
             }
-            else // rightJustify
+            else
             {
-                if (typeof(T) == typeof(string))
+                FormatToRightJustify(ref sb, arg, width, format, argName);
+            }
+        }
+
+        private static void FormatToRightJustify<TBufferWriter, T>(ref TBufferWriter sb, T arg, int width, <#= isUtf16 ? "ReadOnlySpan<char>" : "StandardFormat" #> format, string argName)
+            where TBufferWriter : IBufferWriter<<#= elemType #>>
+        {
+            if (typeof(T) == typeof(string))
+            {
+                var s = Unsafe.As<string>(arg);
+                int padding = width - s.Length;
+                if (padding > 0)
                 {
-                    var s = Unsafe.As<string>(arg);
-                    int padding = width - s.Length;
-                    if (padding > 0)
-                    {
-                        var paddingSpan = sb.GetSpan(padding);
-                        paddingSpan.Fill(sp);
-                        sb.Advance(padding);
-                    }
+                    var paddingSpan = sb.GetSpan(padding);
+                    paddingSpan.Fill(sp);
+                    sb.Advance(padding);
+                }
 
 <# if(isUtf16) { #>
-                    var span = sb.GetSpan(s.Length);
-                    s.AsSpan().CopyTo(span);
-                    sb.Advance(s.Length);
+                var span = sb.GetSpan(s.Length);
+                s.AsSpan().CopyTo(span);
+                sb.Advance(s.Length);
 <# }else { #>
-                    ZString.AppendChars(ref sb, s.AsSpan());
+                ZString.AppendChars(ref sb, s.AsSpan());
 <# } #>
-                }
-                else
+            }
+            else
+            {
+                Span<<#= elemType #>> s = stackalloc <#= elemType #>[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
+
+                if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
                 {
-                    Span<<#= elemType #>> s = stackalloc <#= elemType #>[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
-
-                    if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
+                    s = stackalloc <#= elemType #>[s.Length * 2];
+                    if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
                     {
-                        s = stackalloc <#= elemType #>[s.Length * 2];
-                        if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
-                        {
-                            ExceptionUtil.ThrowArgumentException(argName);
-                        }
+                        ExceptionUtil.ThrowArgumentException(argName);
                     }
-
-                    int padding = width - charsWritten;
-                    if (padding > 0)
-                    {
-                        var paddingSpan = sb.GetSpan(padding);
-                        paddingSpan.Fill(sp);
-                        sb.Advance(padding);
-                    }
-
-                    var span = sb.GetSpan(charsWritten);
-                    s.CopyTo(span);
-                    sb.Advance(charsWritten);
                 }
+
+                int padding = width - charsWritten;
+                if (padding > 0)
+                {
+                    var paddingSpan = sb.GetSpan(padding);
+                    paddingSpan.Fill(sp);
+                    sb.Advance(padding);
+                }
+
+                var span = sb.GetSpan(charsWritten);
+                s.CopyTo(span);
+                sb.Advance(charsWritten);
             }
         }
     }
+
 <# } // foreach(utf) #>
 }

--- a/src/ZString/FormatHelper.tt
+++ b/src/ZString/FormatHelper.tt
@@ -1,0 +1,99 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+<#@ include file="T4Common.t4" once="true" #>
+using System;
+using System.Text;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Cysharp.Text
+{
+<# foreach(var utf in utfTypes ) { var isUtf16 = (utf == "Utf16"); var elemType = isUtf16 ? "char" : "byte"; #>
+    internal static partial class <#= utf #>PreparedFormat
+    {
+        public static void FormatTo<TBufferWriter, T>(ref TBufferWriter sb, in FormatSegment item, T arg, string argName)
+            where TBufferWriter : IBufferWriter<<#= elemType #>>
+        {
+            const <#= elemType #> sp = (<#= elemType #>)' ';
+            var width = item.Alignment;
+            var format = <#= isUtf16 ? "item.FormatString.AsSpan(item.Offset, item.Count)" : "item.StandardFormat" #>;
+
+            if (width <= 0) // leftJustify
+            {
+                width *= -1;
+
+                var span = sb.GetSpan(0);
+                if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out var argWritten, format))
+                {
+                    sb.Advance(0);
+                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
+                    if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, span, out argWritten, format))
+                    {
+                        ExceptionUtil.ThrowArgumentException(argName);
+                    }
+                }
+                sb.Advance(argWritten);
+
+                int padding = width - argWritten;
+                if (width > 0 && padding > 0)
+                {
+                    var paddingSpan = sb.GetSpan(padding);
+                    paddingSpan.Fill(sp);
+                    sb.Advance(padding);
+                }
+            }
+            else // rightJustify
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    var s = Unsafe.As<string>(arg);
+                    int padding = width - s.Length;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+<# if(isUtf16) { #>
+                    var span = sb.GetSpan(s.Length);
+                    s.AsSpan().CopyTo(span);
+                    sb.Advance(s.Length);
+<# }else { #>
+                    ZString.AppendChars(ref sb, s.AsSpan());
+<# } #>
+                }
+                else
+                {
+                    Span<<#= elemType #>> s = stackalloc <#= elemType #>[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
+
+                    if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
+                    {
+                        s = stackalloc <#= elemType #>[s.Length * 2];
+                        if (!<#= utf #>ValueStringBuilder.FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
+                        {
+                            ExceptionUtil.ThrowArgumentException(argName);
+                        }
+                    }
+
+                    int padding = width - charsWritten;
+                    if (padding > 0)
+                    {
+                        var paddingSpan = sb.GetSpan(padding);
+                        paddingSpan.Fill(sp);
+                        sb.Advance(padding);
+                    }
+
+                    var span = sb.GetSpan(charsWritten);
+                    s.CopyTo(span);
+                    sb.Advance(charsWritten);
+                }
+            }
+        }
+    }
+<# } // foreach(utf) #>
+}

--- a/src/ZString/FormatParser.cs
+++ b/src/ZString/FormatParser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
 {
@@ -11,45 +12,207 @@ namespace Cysharp.Text
             public readonly int Index;
             public readonly ReadOnlySpan<char> FormatString;
             public readonly int LastIndex;
+            public readonly int Alignment;
 
-            public ParseResult(int index, ReadOnlySpan<char> formatString, int lastIndex)
+            public ParseResult(int index, ReadOnlySpan<char> formatString, int lastIndex, int alignment)
             {
                 Index = index;
                 FormatString = formatString;
                 LastIndex = lastIndex;
+                Alignment = alignment;
             }
         }
 
-        public static ParseResult Parse(ReadOnlySpan<char> format)
+        internal const int ArgLengthLimit = 16;
+        internal const int WidthLimit = 1000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
+
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParserScanResult ScanFormatString(ReadOnlySpan<char> format, ref int i)
         {
-            int index = -1;
-            var formatStart = -1;
+            var len = format.Length;
+            char c = format[i];
 
-            // ignore start '{'
-            for (int i = 1; i < format.Length; i++)
+            i++; // points netxt char
+            if (c == '}')
             {
-                if (format[i] == '}')
+                // skip escaped '}'
+                if (i < len && format[i] == '}')
                 {
-                    if (index == -1)
-                    {
-                        index = Int32.Parse(format.Slice(1, i - 1));
-                        return new ParseResult(index, default, i);
-                    }
-                    else
-                    {
-                        var formatString = format.Slice(formatStart, i - formatStart);
-                        return new ParseResult(index, formatString, i);
-                    }
+                    i++;
+                    return ParserScanResult.EscapedChar;
                 }
-
-                if (index == -1 && (format[i] == ',' && format[i - 1] != '\\') || (format[i] == ':' && format[i - 1] != '\\'))
+                else
                 {
-                    index = Int32.Parse(format.Slice(1, i - 1));
-                    formatStart = i + 1;
+                    ExceptionUtil.ThrowFormatError();
+                    return ParserScanResult.NormalChar; // NOTE Don't reached
                 }
             }
+            else if (c == '{')
+            {
+                // skip escaped '{'
+                if (i < len && format[i] == '{')
+                {
+                    i++;
+                    return ParserScanResult.EscapedChar;
+                }
+                else
+                {
+                    i--;
+                    return ParserScanResult.BraceOpen;
+                }
+            }
+            else
+            {
+                // ch is the normal char OR end of text
+                return ParserScanResult.NormalChar;
+            }
+        }
 
-            throw new FormatException("Invalid format string. format:" + format.ToString());
+        // Accept only non-unicode numbers
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool IsDigit(char c) => '0' <= c && c <= '9';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParseResult Parse(string format, int i)
+        {
+            char c = default;
+            var len = format.Length;
+
+            i++; // Skip `{`
+
+            //  === Index Component ===
+            //   ('0'-'9')+ WS*
+
+            if (i == len || !IsDigit(c = format[i]))
+            {
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            int paramIndex = 0;
+            do
+            {
+                paramIndex = (paramIndex * 10) + c - '0';
+
+                if (++i == len)
+                    ExceptionUtil.ThrowFormatError();
+
+                c = format[i];
+            }
+            while (IsDigit(c) && paramIndex < ArgLengthLimit);
+
+            if (paramIndex >= ArgLengthLimit)
+            {
+                ExceptionUtil.ThrowFormatException();
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Alignment Component ===
+            //   comma WS* minus? ('0'-'9')+ WS*
+
+            int alignment = 0;
+
+            if (c == ',')
+            {
+                i++;
+
+                // skip whitespace.
+                while (i < len && (c = format[i]) == ' ')
+                    i++;
+
+                if (i == len)
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                var leftJustify = false;
+                if (c == '-')
+                {
+                    leftJustify = true;
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+
+                if (!IsDigit(c))
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                do
+                {
+                    alignment = (alignment * 10) + c - '0';
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+                while (IsDigit(c) && alignment < WidthLimit);
+
+                if (leftJustify)
+                    alignment *= -1;
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Format String Component ===
+
+            ReadOnlySpan<char> itemFormatSpan = default;
+
+            if (c == ':')
+            {
+                i++;
+                int formatStart = i;
+
+                while (true)
+                {
+                    if (i == len)
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+                    c = format[i];
+
+                    if (c == '}')
+                    {
+                        break;
+                    }
+                    else if (c == '{')
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+
+                    i++;
+                }
+
+                // has format
+                if (i > formatStart)
+                {
+                    itemFormatSpan = format.AsSpan(formatStart, i - formatStart);
+                }
+            }
+            else if (c != '}')
+            {
+                // Unexpected character
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            i++; // Skip `}`
+            return new ParseResult(paramIndex, itemFormatSpan, i, alignment);
         }
     }
+    internal enum ParserScanResult
+    {
+        BraceOpen,
+        EscapedChar,
+        NormalChar,
+    }
+
 }

--- a/src/ZString/PreparedFormat.cs
+++ b/src/ZString/PreparedFormat.cs
@@ -9,12 +9,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -50,7 +50,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -74,12 +74,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -115,7 +115,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -144,12 +144,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -185,7 +185,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -219,12 +219,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -260,7 +260,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -299,12 +299,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -340,7 +340,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -384,12 +384,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -425,7 +425,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -474,12 +474,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -515,7 +515,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -569,12 +569,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -610,7 +610,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -669,12 +669,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -710,7 +710,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -774,12 +774,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -815,7 +815,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -884,12 +884,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -925,7 +925,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -999,12 +999,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1040,7 +1040,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1119,12 +1119,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1160,7 +1160,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1244,12 +1244,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1285,7 +1285,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1374,12 +1374,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1415,7 +1415,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1509,12 +1509,12 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf16FormatSegment[] segments;
 
         public Utf16PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, false);
+            this.segments = PreparedFormatHelper.Utf16Parse(format);
 
             var size = 0;
             foreach (var item in segments)
@@ -1550,7 +1550,7 @@ namespace Cysharp.Text
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf16FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
@@ -1649,12 +1649,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1684,19 +1685,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1715,12 +1715,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1750,19 +1751,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1786,12 +1786,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1821,19 +1822,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1862,12 +1862,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1897,19 +1898,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -1943,12 +1943,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -1978,19 +1979,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2029,12 +2029,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2064,19 +2065,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2120,12 +2120,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2155,19 +2156,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2216,12 +2216,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2251,19 +2252,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2317,12 +2317,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2352,19 +2353,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2423,12 +2423,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2458,19 +2459,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2534,12 +2534,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2569,19 +2570,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2650,12 +2650,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2685,19 +2686,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2771,12 +2771,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2806,19 +2807,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -2897,12 +2897,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -2932,19 +2933,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -3028,12 +3028,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -3063,19 +3064,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:
@@ -3164,12 +3164,13 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly Utf8FormatSegment[] segments;
+        readonly byte[] utf8PreEncodedbuffer;
 
         public Utf8PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, true);
+            this.segments = PreparedFormatHelper.Utf8Parse(format, out utf8PreEncodedbuffer);
 
             var size = 0;
             foreach (var item in segments)
@@ -3199,19 +3200,18 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<byte>
         {
-            var formatSpan = FormatString.AsSpan();
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case Utf8FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
                             break;
                         }
                     case 0:

--- a/src/ZString/PreparedFormat.cs
+++ b/src/ZString/PreparedFormat.cs
@@ -44,23 +44,27 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
-                        }
-                        break;
-                    case 0:
-                        {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
                         }
+                    case 0:
+                        {
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
+                            break;
+                        }
+                    default:
+                        break;
                 }
             }
         }
@@ -105,28 +109,32 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -171,33 +179,37 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -242,38 +254,42 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -318,43 +334,47 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -399,48 +419,52 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -485,53 +509,57 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -576,58 +604,62 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -672,63 +704,67 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -773,68 +809,72 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -879,73 +919,77 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -990,78 +1034,82 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1106,83 +1154,87 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1227,88 +1279,92 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf16FormatHelper.FormatTo(ref sb, arg14, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg14));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1353,93 +1409,97 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf16FormatHelper.FormatTo(ref sb, arg14, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf16FormatHelper.FormatTo(ref sb, arg15, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg15));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1484,98 +1544,102 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<char>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf16FormatHelper.FormatTo(ref sb, arg1, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf16FormatHelper.FormatTo(ref sb, arg2, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf16FormatHelper.FormatTo(ref sb, arg3, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf16FormatHelper.FormatTo(ref sb, arg4, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf16FormatHelper.FormatTo(ref sb, arg5, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf16FormatHelper.FormatTo(ref sb, arg6, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf16FormatHelper.FormatTo(ref sb, arg7, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf16FormatHelper.FormatTo(ref sb, arg8, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf16FormatHelper.FormatTo(ref sb, arg9, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf16FormatHelper.FormatTo(ref sb, arg10, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf16FormatHelper.FormatTo(ref sb, arg11, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf16FormatHelper.FormatTo(ref sb, arg12, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf16FormatHelper.FormatTo(ref sb, arg13, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf16FormatHelper.FormatTo(ref sb, arg14, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf16FormatHelper.FormatTo(ref sb, arg15, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg15));
                             break;
                         }
                     case 15:
                         {
-                            Utf16PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            Utf16FormatHelper.FormatTo(ref sb, arg16, item.Alignment, formatSpan.Slice(item.Offset, item.Count), nameof(arg16));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1620,24 +1684,28 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
-                        }
-                        break;
-                    case 0:
-                        {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
                         }
+                    case 0:
+                        {
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
+                            break;
+                        }
+                    default:
+                        break;
                 }
             }
         }
@@ -1682,29 +1750,33 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1749,34 +1821,38 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1821,39 +1897,43 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1898,44 +1978,48 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -1980,49 +2064,53 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2067,54 +2155,58 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2159,59 +2251,63 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2256,64 +2352,68 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2358,69 +2458,73 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2465,74 +2569,78 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2577,79 +2685,83 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2694,84 +2806,88 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2816,89 +2932,93 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref sb, arg14, item.Alignment, item.StandardFormat, nameof(arg14));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -2943,94 +3063,98 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref sb, arg14, item.Alignment, item.StandardFormat, nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref sb, arg15, item.Alignment, item.StandardFormat, nameof(arg15));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }
@@ -3075,99 +3199,103 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
             where TBufferWriter : IBufferWriter<byte>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
+                            break;
                         }
-                        break;
                     case 0:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref sb, arg1, item.Alignment, item.StandardFormat, nameof(arg1));
                             break;
                         }
                     case 1:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref sb, arg2, item.Alignment, item.StandardFormat, nameof(arg2));
                             break;
                         }
                     case 2:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref sb, arg3, item.Alignment, item.StandardFormat, nameof(arg3));
                             break;
                         }
                     case 3:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref sb, arg4, item.Alignment, item.StandardFormat, nameof(arg4));
                             break;
                         }
                     case 4:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref sb, arg5, item.Alignment, item.StandardFormat, nameof(arg5));
                             break;
                         }
                     case 5:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref sb, arg6, item.Alignment, item.StandardFormat, nameof(arg6));
                             break;
                         }
                     case 6:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref sb, arg7, item.Alignment, item.StandardFormat, nameof(arg7));
                             break;
                         }
                     case 7:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref sb, arg8, item.Alignment, item.StandardFormat, nameof(arg8));
                             break;
                         }
                     case 8:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref sb, arg9, item.Alignment, item.StandardFormat, nameof(arg9));
                             break;
                         }
                     case 9:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref sb, arg10, item.Alignment, item.StandardFormat, nameof(arg10));
                             break;
                         }
                     case 10:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref sb, arg11, item.Alignment, item.StandardFormat, nameof(arg11));
                             break;
                         }
                     case 11:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref sb, arg12, item.Alignment, item.StandardFormat, nameof(arg12));
                             break;
                         }
                     case 12:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref sb, arg13, item.Alignment, item.StandardFormat, nameof(arg13));
                             break;
                         }
                     case 13:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref sb, arg14, item.Alignment, item.StandardFormat, nameof(arg14));
                             break;
                         }
                     case 14:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref sb, arg15, item.Alignment, item.StandardFormat, nameof(arg15));
                             break;
                         }
                     case 15:
                         {
-                            Utf8PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            Utf8FormatHelper.FormatTo(ref sb, arg16, item.Alignment, item.StandardFormat, nameof(arg16));
                             break;
                         }
+                    default:
+                        break;
                 }
             }
         }

--- a/src/ZString/PreparedFormat.cs
+++ b/src/ZString/PreparedFormat.cs
@@ -46,40 +46,25 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
@@ -122,55 +107,30 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
@@ -213,70 +173,35 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
@@ -319,85 +244,40 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
@@ -440,100 +320,45 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
@@ -576,115 +401,50 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
@@ -727,130 +487,55 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
@@ -893,145 +578,60 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
@@ -1074,160 +674,65 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
@@ -1270,175 +775,70 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
@@ -1481,190 +881,75 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
@@ -1707,205 +992,80 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
@@ -1948,220 +1108,85 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
@@ -2204,235 +1229,90 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
@@ -2475,250 +1355,95 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf16PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
@@ -2761,265 +1486,100 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 15:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf16ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out var argWritten, item.FormatString.AsSpan()))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf16ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out argWritten, item.FormatString.AsSpan()))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg16));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
+                    case 15:
+                        {
+                            Utf16PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1>
     {
         public string FormatString { get; }
@@ -3062,41 +1622,26 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2>
     {
         public string FormatString { get; }
@@ -3139,56 +1684,31 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3>
     {
         public string FormatString { get; }
@@ -3231,71 +1751,36 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4>
     {
         public string FormatString { get; }
@@ -3338,86 +1823,41 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5>
     {
         public string FormatString { get; }
@@ -3460,101 +1900,46 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6>
     {
         public string FormatString { get; }
@@ -3597,116 +1982,51 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7>
     {
         public string FormatString { get; }
@@ -3749,131 +2069,56 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8>
     {
         public string FormatString { get; }
@@ -3916,146 +2161,61 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>
     {
         public string FormatString { get; }
@@ -4098,161 +2258,66 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>
     {
         public string FormatString { get; }
@@ -4295,176 +2360,71 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>
     {
         public string FormatString { get; }
@@ -4507,191 +2467,76 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>
     {
         public string FormatString { get; }
@@ -4734,206 +2579,81 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>
     {
         public string FormatString { get; }
@@ -4976,221 +2696,86 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>
     {
         public string FormatString { get; }
@@ -5233,236 +2818,91 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>
     {
         public string FormatString { get; }
@@ -5505,251 +2945,96 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
                 }
             }
         }
     }
-
     public sealed partial class Utf8PreparedFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>
     {
         public string FormatString { get; }
@@ -5792,264 +3077,99 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
-                        case 0:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T1>.TryFormatDelegate(arg1, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg1));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 1:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T2>.TryFormatDelegate(arg2, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg2));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 2:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T3>.TryFormatDelegate(arg3, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg3));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 3:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T4>.TryFormatDelegate(arg4, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg4));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 4:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T5>.TryFormatDelegate(arg5, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg5));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 5:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T6>.TryFormatDelegate(arg6, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg6));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 6:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T7>.TryFormatDelegate(arg7, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg7));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 7:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T8>.TryFormatDelegate(arg8, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg8));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 8:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T9>.TryFormatDelegate(arg9, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg9));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 9:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T10>.TryFormatDelegate(arg10, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg10));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 10:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T11>.TryFormatDelegate(arg11, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg11));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 11:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T12>.TryFormatDelegate(arg12, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg12));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 12:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T13>.TryFormatDelegate(arg13, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg13));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 13:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T14>.TryFormatDelegate(arg14, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg14));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 14:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T15>.TryFormatDelegate(arg15, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg15));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        case 15:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!Utf8ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out var argWritten, item.StandardFormat))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T16>.TryFormatDelegate(arg16, span, out argWritten, item.StandardFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg16));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-                        default:
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
+                        }
+                        break;
+                    case 0:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg1, nameof(arg1));
                             break;
-                    }
+                        }
+                    case 1:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg2, nameof(arg2));
+                            break;
+                        }
+                    case 2:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg3, nameof(arg3));
+                            break;
+                        }
+                    case 3:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg4, nameof(arg4));
+                            break;
+                        }
+                    case 4:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg5, nameof(arg5));
+                            break;
+                        }
+                    case 5:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg6, nameof(arg6));
+                            break;
+                        }
+                    case 6:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg7, nameof(arg7));
+                            break;
+                        }
+                    case 7:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg8, nameof(arg8));
+                            break;
+                        }
+                    case 8:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg9, nameof(arg9));
+                            break;
+                        }
+                    case 9:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg10, nameof(arg10));
+                            break;
+                        }
+                    case 10:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg11, nameof(arg11));
+                            break;
+                        }
+                    case 11:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg12, nameof(arg12));
+                            break;
+                        }
+                    case 12:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg13, nameof(arg13));
+                            break;
+                        }
+                    case 13:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg14, nameof(arg14));
+                            break;
+                        }
+                    case 14:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg15, nameof(arg15));
+                            break;
+                        }
+                    case 15:
+                        {
+                            Utf8PreparedFormat.FormatTo(ref sb, item, arg16, nameof(arg16));
+                            break;
+                        }
                 }
             }
         }
     }
-
 }

--- a/src/ZString/PreparedFormat.tt
+++ b/src/ZString/PreparedFormat.tt
@@ -18,12 +18,15 @@ namespace Cysharp.Text
         public string FormatString { get; }
         public int MinSize { get; }
 
-        readonly FormatSegment[] segments;
+        readonly <#= utf #>FormatSegment[] segments;
+<# if(!isUtf16) { #>
+        readonly byte[] utf8PreEncodedbuffer;
+<# } #>
 
         public <#= utf #>PreparedFormat(string format)
         {
             this.FormatString = format;
-            this.segments = PreparedFormatHelper.Parse(format, <#= (utf == "Utf16" ? false : true).ToString().ToLower() #>);
+            this.segments = PreparedFormatHelper.<#= utf #>Parse(format<#= (!isUtf16 ? ", out utf8PreEncodedbuffer" : "")  #>);
 
             var size = 0;
             foreach (var item in segments)
@@ -53,25 +56,22 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, <#= CreateParameters(i) #>)
             where TBufferWriter : IBufferWriter<<#= isUtf16 ? "char" : "byte" #>>
         {
+<# if(isUtf16) { #>
             var formatSpan = FormatString.AsSpan();
+<# } else { #>
+            var formatSpan = utf8PreEncodedbuffer.AsSpan();
+<# } #>
 
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
-                    case FormatSegment.NotFormatIndex:
+                    case <#= utf #>FormatSegment.NotFormatIndex:
                         {
                             var strSpan = formatSpan.Slice(item.Offset, item.Count);
-<# if(isUtf16) { #>
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
-<# } else { #>
-                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                            var span = sb.GetSpan(size);
-                            var count = Encoding.UTF8.GetBytes(strSpan, span);
-                            sb.Advance(count);
-<# } #>
                             break;
                         }
 <# for(var j = 0; j < i; j++) { #>

--- a/src/ZString/PreparedFormat.tt
+++ b/src/ZString/PreparedFormat.tt
@@ -55,49 +55,34 @@ namespace Cysharp.Text
         {
             foreach (var item in segments)
             {
-                if (!item.IsFormatArgument)
+                switch (item.FormatIndex)
                 {
-                    var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                    case FormatSegment.NotFormatIndex:
+                        {
+                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
 <# if(isUtf16) { #>
-                    var span = sb.GetSpan(item.Count);
-                    strSpan.TryCopyTo(span);
-                    sb.Advance(item.Count);
+                            var span = sb.GetSpan(item.Count);
+                            strSpan.TryCopyTo(span);
+                            sb.Advance(item.Count);
 <# } else { #>
-                    var size = Encoding.UTF8.GetMaxByteCount(item.Count);
-                    var span = sb.GetSpan(size);
-                    var count = Encoding.UTF8.GetBytes(strSpan, span);
-                    sb.Advance(count);
+                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var span = sb.GetSpan(size);
+                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            sb.Advance(count);
 <# } #>
-                }
-                else
-                {
-                    switch (item.FormatIndex)
-                    {
+                        }
+                        break;
 <# for(var j = 0; j < i; j++) { #>
-                        case <#= j #>:
-                            {
-                                var span = sb.GetSpan(0);
-                                if (!<#= utf #>ValueStringBuilder.FormatterCache<T<#= j + 1 #>>.TryFormatDelegate(arg<#= j + 1 #>, span, out var argWritten, <#= isUtf16 ? "item.FormatString.AsSpan()" : "item.StandardFormat" #>))
-                                {
-                                    sb.Advance(0);
-                                    span = sb.GetSpan(Math.Max(span.Length + 1, argWritten));
-                                    if (!<#= utf #>ValueStringBuilder.FormatterCache<T<#= j + 1 #>>.TryFormatDelegate(arg<#= j + 1 #>, span, out argWritten, <#= isUtf16 ? "item.FormatString.AsSpan()" : "item.StandardFormat" #>))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg<#= j + 1 #>));
-                                    }
-                                }
-                                sb.Advance(argWritten);
-                                break;
-                            }
-<# } // for(j) #>
-                        default:
+                    case <#= j #>:
+                        {
+                            <#= utf #>PreparedFormat.FormatTo(ref sb, item, arg<#= j + 1 #>, nameof(arg<#= j + 1 #>));
                             break;
-                    }
+                        }
+<# } // for(j) #>
                 }
             }
         }
     }
-
 <# } // for(i) #>
 <# } // foreach(utf) #>
 }

--- a/src/ZString/PreparedFormat.tt
+++ b/src/ZString/PreparedFormat.tt
@@ -53,32 +53,36 @@ namespace Cysharp.Text
         public void FormatTo<TBufferWriter>(ref TBufferWriter sb, <#= CreateParameters(i) #>)
             where TBufferWriter : IBufferWriter<<#= isUtf16 ? "char" : "byte" #>>
         {
+            var formatSpan = FormatString.AsSpan();
+
             foreach (var item in segments)
             {
                 switch (item.FormatIndex)
                 {
                     case FormatSegment.NotFormatIndex:
                         {
-                            var strSpan = FormatString.AsSpan(item.Offset, item.Count);
+                            var strSpan = formatSpan.Slice(item.Offset, item.Count);
 <# if(isUtf16) { #>
                             var span = sb.GetSpan(item.Count);
                             strSpan.TryCopyTo(span);
                             sb.Advance(item.Count);
 <# } else { #>
-                            var size = Utf8ValueStringBuilder.UTF8NoBom.GetMaxByteCount(item.Count);
+                            var size = Encoding.UTF8.GetMaxByteCount(item.Count);
                             var span = sb.GetSpan(size);
-                            var count = Utf8ValueStringBuilder.UTF8NoBom.GetBytes(strSpan, span);
+                            var count = Encoding.UTF8.GetBytes(strSpan, span);
                             sb.Advance(count);
 <# } #>
+                            break;
                         }
-                        break;
 <# for(var j = 0; j < i; j++) { #>
                     case <#= j #>:
                         {
-                            <#= utf #>PreparedFormat.FormatTo(ref sb, item, arg<#= j + 1 #>, nameof(arg<#= j + 1 #>));
+                            <#= utf #>FormatHelper.FormatTo(ref sb, arg<#= j + 1 #>, item.Alignment, <#= isUtf16 ? "formatSpan.Slice(item.Offset, item.Count)" : "item.StandardFormat" #>, nameof(arg<#= j + 1 #>));
                             break;
                         }
 <# } // for(j) #>
+                    default:
+                        break;
                 }
             }
         }

--- a/src/ZString/PreparedFormatHelper.cs
+++ b/src/ZString/PreparedFormatHelper.cs
@@ -1,20 +1,20 @@
 ﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Text;
 
 namespace Cysharp.Text
 {
     internal static class PreparedFormatHelper
     {
-        internal static FormatSegment[] Parse(string format, bool withStandardFormat)
+        internal static Utf16FormatSegment[] Utf16Parse(string format)
         {
             if (format == null)
             {
                 throw new ArgumentNullException(nameof(format));
             }
 
-            var list = new List<FormatSegment>();
+            var list = new List<Utf16FormatSegment>();
 
             int i = 0;
             int len = format.Length;
@@ -42,7 +42,7 @@ namespace Cysharp.Text
 
                     if (size != 0)
                     {
-                        list.Add(new FormatSegment(copyFrom, size, FormatSegment.NotFormatIndex, format, default, 0));
+                        list.Add(new Utf16FormatSegment(copyFrom, size, Utf16FormatSegment.NotFormatIndex, 0));
                     }
 
                     copyFrom = i;
@@ -63,46 +63,117 @@ namespace Cysharp.Text
                 copyFrom = indexParse.LastIndex; // continue after '}'
                 i = indexParse.LastIndex;
 
-                list.Add(new FormatSegment(indexParse.LastIndex - indexParse.FormatString.Length - 1, indexParse.FormatString.Length, indexParse.Index, format, withStandardFormat, indexParse.Alignment));
+                list.Add(new Utf16FormatSegment(indexParse.LastIndex - indexParse.FormatString.Length - 1, indexParse.FormatString.Length, indexParse.Index, indexParse.Alignment));
+            }
 
+            return list.ToArray();
+        }
+
+        internal static Utf8FormatSegment[] Utf8Parse(string format, out byte[] utf8buffer)
+        {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+
+            var list = new List<Utf8FormatSegment>();
+            utf8buffer = new byte[Encoding.UTF8.GetMaxByteCount(format.Length)];
+            var bufOffset = 0;
+
+            int i = 0;
+            int len = format.Length;
+
+            var copyFrom = 0;
+            var formatSpan = format.AsSpan();
+
+            while (true)
+            {
+                while (i < len)
+                {
+                    var parserScanResult = FormatParser.ScanFormatString(formatSpan, ref i);
+
+                    if (ParserScanResult.NormalChar == parserScanResult && i < len)
+                    {
+                        // skip normal char
+                        continue;
+                    }
+
+                    var size = i - copyFrom;
+                    if (ParserScanResult.EscapedChar == parserScanResult)
+                    {
+                        size--;
+                    }
+
+                    if (size != 0)
+                    {
+                        var utf8size = Encoding.UTF8.GetBytes(format, copyFrom, size, utf8buffer, bufOffset);
+                        list.Add(new Utf8FormatSegment(bufOffset, utf8size, Utf8FormatSegment.NotFormatIndex, default, 0));
+                        bufOffset += utf8size;
+                    }
+
+                    copyFrom = i;
+
+                    if (ParserScanResult.BraceOpen == parserScanResult)
+                    {
+                        break;
+                    }
+                }
+
+                if (i >= len)
+                {
+                    break;
+                }
+
+                // Here it is before `{`.
+                var indexParse = FormatParser.Parse(format, i);
+                copyFrom = indexParse.LastIndex; // continue after '}'
+                i = indexParse.LastIndex;
+                list.Add(new Utf8FormatSegment(0, 0, indexParse.Index, StandardFormat.Parse(indexParse.FormatString), indexParse.Alignment));
             }
 
             return list.ToArray();
         }
     }
 
-    internal readonly struct FormatSegment
+    internal readonly struct Utf8FormatSegment
     {
         public const int NotFormatIndex = -1;
 
-        //public readonly bool IsFormatArgument;
-        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
-
         public readonly int Offset;
         public readonly int Count;
-        public readonly int Alignment;
         public readonly int FormatIndex;
-        public readonly string FormatString;
-
-        // Utf8
         public readonly StandardFormat StandardFormat;
+        public readonly int Alignment;
 
-        public FormatSegment(int offset, int count, int formatIndex, string formatString, bool utf8, int alignment)
+        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+
+        public Utf8FormatSegment(int offset, int count, int formatIndex, StandardFormat format, int alignment)
         {
             Offset = offset;
             Count = count;
-            //IsFormatArgument = formatIndex != NotFormatIndex;
             FormatIndex = formatIndex;
-            FormatString = formatString;
+            StandardFormat = format;
             Alignment = alignment;
-            if (utf8)
-            {
-                StandardFormat = (formatString != null) ? StandardFormat.Parse(formatString.AsSpan(Offset, Count)) : default;
-            }
-            else
-            {
-                StandardFormat = default;
-            }
+        }
+    }
+
+    internal readonly struct Utf16FormatSegment
+    {
+        public const int NotFormatIndex = -1;
+
+        public readonly int Offset;
+        public readonly int Count;
+        public readonly int FormatIndex;
+        public readonly int Alignment;
+
+        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+
+        public Utf16FormatSegment(int offset, int count, int formatIndex, int alignment)
+        {
+            Offset = offset;
+            Count = count;
+            FormatIndex = formatIndex;
+            Alignment = alignment;
         }
     }
 }

--- a/src/ZString/PreparedFormatHelper.cs
+++ b/src/ZString/PreparedFormatHelper.cs
@@ -75,12 +75,14 @@ namespace Cysharp.Text
     {
         public const int NotFormatIndex = -1;
 
+        //public readonly bool IsFormatArgument;
+        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+
         public readonly int Offset;
         public readonly int Count;
-        public bool IsFormatArgument => FormatIndex != NotFormatIndex;
+        public readonly int Alignment;
         public readonly int FormatIndex;
         public readonly string FormatString;
-        public readonly int Alignment;
 
         // Utf8
         public readonly StandardFormat StandardFormat;
@@ -89,6 +91,7 @@ namespace Cysharp.Text
         {
             Offset = offset;
             Count = count;
+            //IsFormatArgument = formatIndex != NotFormatIndex;
             FormatIndex = formatIndex;
             FormatString = formatString;
             Alignment = alignment;

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -7,10 +7,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -33,28 +39,32 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -68,14 +78,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2>(string format, T1 arg1, T2 arg2)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -98,31 +113,35 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -136,14 +155,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -166,34 +190,38 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -207,14 +235,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -237,37 +270,41 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -281,14 +318,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -311,40 +353,44 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -358,14 +404,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -388,43 +439,47 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -438,14 +493,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -468,46 +528,50 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -521,14 +585,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -551,49 +620,53 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -607,14 +680,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -637,52 +715,56 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -696,14 +778,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -726,55 +813,59 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -788,14 +879,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -818,58 +914,62 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -883,14 +983,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -913,61 +1018,65 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -981,14 +1090,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1011,64 +1125,68 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1082,14 +1200,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1112,67 +1235,71 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, indexParse.FormatString, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1186,14 +1313,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1216,70 +1348,74 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, indexParse.FormatString, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, indexParse.FormatString, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1293,14 +1429,19 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1323,73 +1464,77 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, indexParse.FormatString, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, indexParse.FormatString, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, indexParse.FormatString, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, indexParse.FormatString, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, indexParse.FormatString, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, indexParse.FormatString, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, indexParse.FormatString, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, indexParse.FormatString, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, indexParse.FormatString, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, indexParse.FormatString, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, indexParse.FormatString, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, indexParse.FormatString, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, indexParse.FormatString, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, indexParse.FormatString, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, indexParse.FormatString, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
                             continue;
                         case 15:
-                            AppendFormatInternal(arg16, indexParse.FormatString, nameof(arg16));
+                            AppendFormatInternal(arg16, indexParse.Alignment, indexParse.FormatString, nameof(arg16));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -1403,6 +1548,5 @@ namespace Cysharp.Text
                 }
             }
         }
-
     }
 }

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
@@ -15,10 +15,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<<#= CreateTypeArgument(i) #>>(string format, <#= CreateParameters(i) #>)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -41,14 +47,14 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     switch (indexParse.Index)
                     {
 <# for(var j = 0; j < i; j++) { #>
                         case <#= j #>:
-                            AppendFormatInternal(arg<#= j + 1 #>, indexParse.FormatString, nameof(arg<#= j + 1 #>));
+                            AppendFormatInternal(arg<#= j + 1 #>, indexParse.Alignment, indexParse.FormatString, nameof(arg<#= j + 1 #>));
                             continue;
 <# } #>
                         default:
@@ -56,15 +62,19 @@ namespace Cysharp.Text
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
             }
@@ -78,7 +88,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
 <# } #>
     }
 }

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
@@ -8,10 +8,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1>(string format, T1 arg1)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -34,28 +40,33 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -74,10 +85,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2>(string format, T1 arg1, T2 arg2)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -100,31 +117,36 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -143,10 +165,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -169,34 +197,39 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -215,10 +248,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -241,37 +280,42 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -290,10 +334,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -316,40 +366,45 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -368,10 +423,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -394,43 +455,48 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -449,10 +515,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -475,46 +547,51 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -533,10 +610,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -559,49 +642,54 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -620,10 +708,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -646,52 +740,57 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -710,10 +809,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -736,55 +841,60 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -803,10 +913,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -829,58 +945,63 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -899,10 +1020,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -925,61 +1052,66 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -998,10 +1130,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1024,64 +1162,69 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -1100,10 +1243,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1126,67 +1275,72 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, writeFormat, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -1205,10 +1359,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1231,70 +1391,75 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, writeFormat, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, writeFormat, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 
@@ -1313,10 +1478,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -1339,73 +1510,78 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
                         case 0:
-                            AppendFormatInternal(arg1, writeFormat, nameof(arg1));
+                            AppendFormatInternal(arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            AppendFormatInternal(arg2, writeFormat, nameof(arg2));
+                            AppendFormatInternal(arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            AppendFormatInternal(arg3, writeFormat, nameof(arg3));
+                            AppendFormatInternal(arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            AppendFormatInternal(arg4, writeFormat, nameof(arg4));
+                            AppendFormatInternal(arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            AppendFormatInternal(arg5, writeFormat, nameof(arg5));
+                            AppendFormatInternal(arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            AppendFormatInternal(arg6, writeFormat, nameof(arg6));
+                            AppendFormatInternal(arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            AppendFormatInternal(arg7, writeFormat, nameof(arg7));
+                            AppendFormatInternal(arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            AppendFormatInternal(arg8, writeFormat, nameof(arg8));
+                            AppendFormatInternal(arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            AppendFormatInternal(arg9, writeFormat, nameof(arg9));
+                            AppendFormatInternal(arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            AppendFormatInternal(arg10, writeFormat, nameof(arg10));
+                            AppendFormatInternal(arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            AppendFormatInternal(arg11, writeFormat, nameof(arg11));
+                            AppendFormatInternal(arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            AppendFormatInternal(arg12, writeFormat, nameof(arg12));
+                            AppendFormatInternal(arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            AppendFormatInternal(arg13, writeFormat, nameof(arg13));
+                            AppendFormatInternal(arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            AppendFormatInternal(arg14, writeFormat, nameof(arg14));
+                            AppendFormatInternal(arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            AppendFormatInternal(arg15, writeFormat, nameof(arg15));
+                            AppendFormatInternal(arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         case 15:
-                            AppendFormatInternal(arg16, writeFormat, nameof(arg16));
+                            AppendFormatInternal(arg16, indexParse.Alignment, writeFormat, nameof(arg16));
                             continue;
                         default:
                             ThrowFormatException();
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
@@ -16,10 +16,16 @@ namespace Cysharp.Text
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<<#= CreateTypeArgument(i) #>>(string format, <#= CreateParameters(i) #>)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -42,15 +48,15 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
 <# for(var j = 0; j < i; j++) { #>
                         case <#= j #>:
-                            AppendFormatInternal(arg<#= j + 1 #>, writeFormat, nameof(arg<#= j + 1 #>));
+                            AppendFormatInternal(arg<#= j + 1 #>, indexParse.Alignment, writeFormat, nameof(arg<#= j + 1 #>));
                             continue;
 <# } #>
                         default:
@@ -58,14 +64,19 @@ namespace Cysharp.Text
                             break;
                     }
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         Append(format.AsSpan(copyFrom, size));
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
                     }
                 }
 

--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -13,7 +13,7 @@ namespace Cysharp.Text
 
         const int ThreadStaticBufferSize = 64444;
         const int DefaultBufferSize = 65536; // use 64K default buffer.
-        internal static readonly Encoding UTF8NoBom = new UTF8Encoding(false);
+        static Encoding UTF8NoBom = new UTF8Encoding(false);
 
         static byte newLine1;
         static byte newLine2;

--- a/src/ZString/ZString.Utf8Format.cs
+++ b/src/ZString/ZString.Utf8Format.cs
@@ -54,7 +54,7 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -93,7 +93,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2)
         {
@@ -140,10 +139,10 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -182,7 +181,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3)
         {
@@ -229,13 +227,13 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -274,7 +272,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
@@ -321,16 +318,16 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -369,7 +366,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
         {
@@ -416,19 +412,19 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -467,7 +463,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
@@ -514,22 +509,22 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -568,7 +563,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
         {
@@ -615,25 +609,25 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -672,7 +666,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
@@ -719,28 +712,28 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -779,7 +772,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
         {
@@ -826,31 +818,31 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -889,7 +881,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
@@ -936,34 +927,34 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1002,7 +993,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
         {
@@ -1049,37 +1039,37 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1118,7 +1108,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
@@ -1165,40 +1154,40 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1237,7 +1226,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
         {
@@ -1284,43 +1272,43 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1359,7 +1347,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
@@ -1406,46 +1393,46 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            Utf8FormatInternal(bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1484,7 +1471,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
         {
@@ -1531,49 +1517,49 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            Utf8FormatInternal(bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            Utf8FormatInternal(bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1612,7 +1598,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(IBufferWriter<byte> bufferWriter, string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
@@ -1659,52 +1644,52 @@ namespace Cysharp.Text
                     switch (indexParse.Index)
                     {
                         case 0:
-                            Utf8FormatInternal(bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg1, indexParse.Alignment, writeFormat, nameof(arg1));
                             continue;
                         case 1:
-                            Utf8FormatInternal(bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg2, indexParse.Alignment, writeFormat, nameof(arg2));
                             continue;
                         case 2:
-                            Utf8FormatInternal(bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg3, indexParse.Alignment, writeFormat, nameof(arg3));
                             continue;
                         case 3:
-                            Utf8FormatInternal(bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg4, indexParse.Alignment, writeFormat, nameof(arg4));
                             continue;
                         case 4:
-                            Utf8FormatInternal(bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg5, indexParse.Alignment, writeFormat, nameof(arg5));
                             continue;
                         case 5:
-                            Utf8FormatInternal(bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg6, indexParse.Alignment, writeFormat, nameof(arg6));
                             continue;
                         case 6:
-                            Utf8FormatInternal(bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg7, indexParse.Alignment, writeFormat, nameof(arg7));
                             continue;
                         case 7:
-                            Utf8FormatInternal(bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg8, indexParse.Alignment, writeFormat, nameof(arg8));
                             continue;
                         case 8:
-                            Utf8FormatInternal(bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg9, indexParse.Alignment, writeFormat, nameof(arg9));
                             continue;
                         case 9:
-                            Utf8FormatInternal(bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg10, indexParse.Alignment, writeFormat, nameof(arg10));
                             continue;
                         case 10:
-                            Utf8FormatInternal(bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg11, indexParse.Alignment, writeFormat, nameof(arg11));
                             continue;
                         case 11:
-                            Utf8FormatInternal(bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg12, indexParse.Alignment, writeFormat, nameof(arg12));
                             continue;
                         case 12:
-                            Utf8FormatInternal(bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg13, indexParse.Alignment, writeFormat, nameof(arg13));
                             continue;
                         case 13:
-                            Utf8FormatInternal(bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg14, indexParse.Alignment, writeFormat, nameof(arg14));
                             continue;
                         case 14:
-                            Utf8FormatInternal(bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg15, indexParse.Alignment, writeFormat, nameof(arg15));
                             continue;
                         case 15:
-                            Utf8FormatInternal(bufferWriter, arg16, indexParse.Alignment, writeFormat, nameof(arg16));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg16, indexParse.Alignment, writeFormat, nameof(arg16));
                             continue;
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -1743,78 +1728,5 @@ namespace Cysharp.Text
                 }
             }
         }
-
-
-        static void Utf8FormatInternal<T>(IBufferWriter<byte> bufferWriter, T arg, int width, StandardFormat format, string argName)
-        {
-            if (width <= 0) // leftJustify
-            {
-                width *= -1;
-
-                var buffer = bufferWriter.GetSpan();
-
-                if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out var written, format))
-                {
-                    bufferWriter.Advance(0);
-                    buffer = bufferWriter.GetSpan(Math.Max(buffer.Length + 1, written));
-
-                    if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out written, format))
-                    {
-                        ExceptionUtil.ThrowArgumentException(argName);
-                    }
-                }
-
-                bufferWriter.Advance(written);
-
-                int padding = width - written;
-                if (width > 0 && padding > 0)
-                {
-                    // TODO Append(' ', padding);
-                    bufferWriter.GetSpan(padding).Fill((byte)' ');  // TODO Fill Method is too slow.
-                    bufferWriter.Advance(padding);
-                }
-            }
-            else // rightJustify
-            {
-                if (typeof(T) == typeof(string))
-                {
-                    var s = Unsafe.As<string>(arg);
-                    int padding = width - s.Length;
-                    if (padding > 0)
-                    {
-                        // TODO Append(' ', padding);
-                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
-                        bufferWriter.Advance(padding);
-                    }
-
-                    ZString.AppendChars(ref bufferWriter, s.AsSpan());
-                }
-                else
-                {
-                    Span<byte> s = stackalloc byte[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
-
-                    if (!FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
-                    {
-                        s = stackalloc byte[s.Length * 2];
-                        if (!FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
-                        {
-                            ExceptionUtil.ThrowArgumentException(argName);
-                        }
-                    }
-
-                    int padding = width - charsWritten;
-                    if (padding > 0)
-                    {
-                        // TODO Append(' ', padding);
-                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
-                        bufferWriter.Advance(padding);
-                    }
-
-                    s.CopyTo(bufferWriter.GetSpan(charsWritten));
-                    bufferWriter.Advance(charsWritten);
-                }
-            }
-        }
-    
     }
 }

--- a/src/ZString/ZString.Utf8Format.tt
+++ b/src/ZString/ZString.Utf8Format.tt
@@ -5,9 +5,11 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 <#@ include file="T4Common.t4" once="true" #>
-using System.Runtime.CompilerServices;
-using System.Buffers;
 using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+using static Cysharp.Text.Utf8ValueStringBuilder;
 
 namespace Cysharp.Text
 {
@@ -17,10 +19,16 @@ namespace Cysharp.Text
         /// <summary>Replaces one or more format items in a string with the string representation of some specified values.</summary>
         public static void Utf8Format<<#= CreateTypeArgument(i) #>>(IBufferWriter<byte> bufferWriter, string format, <#= CreateParameters(i) #>)
         {
+            if (format == null)
+            {
+                throw new ArgumentNullException(nameof(format));
+            }
+            
             var copyFrom = 0;
             for (int i = 0; i < format.Length; i++)
             {
-                if (format[i] == '{')
+                var c = format[i];
+                if (c == '{')
                 {
                     // escape.
                     if (i == format.Length - 1)
@@ -47,28 +55,16 @@ namespace Cysharp.Text
                     }
 
                     // try to find range
-                    var indexParse = FormatParser.Parse(format.AsSpan(i));
-                    copyFrom = i + indexParse.LastIndex + 1;
-                    i = i + indexParse.LastIndex;
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
                     var writeFormat = StandardFormat.Parse(indexParse.FormatString);
                     switch (indexParse.Index)
                     {
 <# for(var j = 0; j < i; j++) { #>
                         case <#= j #>:
-                            {
-                                var buffer = bufferWriter.GetSpan();
-                                if (!Utf8ValueStringBuilder.FormatterCache<T<#= j + 1 #>>.TryFormatDelegate(arg<#= j +1 #>, buffer, out var written, writeFormat))
-                                {
-                                    bufferWriter.Advance(0);
-                                    buffer = bufferWriter.GetSpan(Math.Max(buffer.Length + 1, written));
-                                    if (!Utf8ValueStringBuilder.FormatterCache<T<#= j + 1 #>>.TryFormatDelegate(arg<#= j + 1 #>, buffer, out written, writeFormat))
-                                    {
-                                        ExceptionUtil.ThrowArgumentException(nameof(arg<#= j + 1 #>));
-                                    }
-                                }
-                                bufferWriter.Advance(written);
-                                goto NEXT_LOOP;
-                            }
+                            Utf8FormatInternal(bufferWriter, arg<#= j + 1 #>, indexParse.Alignment, writeFormat, nameof(arg<#= j + 1 #>));
+                            continue;
 <# } #>
                         default:
                             ExceptionUtil.ThrowFormatException();
@@ -77,9 +73,9 @@ namespace Cysharp.Text
 
                     ExceptionUtil.ThrowFormatException();
                 }
-                else if (format[i] == '}')
+                else if (c == '}')
                 {
-                    if (i != format.Length && format[i + 1] == '}')
+                    if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
                         var buffer = bufferWriter.GetSpan(UTF8NoBom.GetMaxByteCount(size));
@@ -87,11 +83,13 @@ namespace Cysharp.Text
                         bufferWriter.Advance(written);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                    	ExceptionUtil.ThrowFormatException();
                     }
                 }
-
-                NEXT_LOOP:
-                continue;
             }
 
             {
@@ -107,5 +105,77 @@ namespace Cysharp.Text
         }
 
 <# } #>
+
+        static void Utf8FormatInternal<T>(IBufferWriter<byte> bufferWriter, T arg, int width, StandardFormat format, string argName)
+        {
+            if (width <= 0) // leftJustify
+            {
+                width *= -1;
+
+                var buffer = bufferWriter.GetSpan();
+
+                if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out var written, format))
+                {
+                    bufferWriter.Advance(0);
+                    buffer = bufferWriter.GetSpan(Math.Max(buffer.Length + 1, written));
+
+                    if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out written, format))
+                    {
+                        ExceptionUtil.ThrowArgumentException(argName);
+                    }
+                }
+
+                bufferWriter.Advance(written);
+
+                int padding = width - written;
+                if (width > 0 && padding > 0)
+                {
+                    // TODO Append(' ', padding);
+                    bufferWriter.GetSpan(padding).Fill((byte)' ');  // TODO Fill Method is too slow.
+                    bufferWriter.Advance(padding);
+                }
+            }
+            else // rightJustify
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    var s = Unsafe.As<string>(arg);
+                    int padding = width - s.Length;
+                    if (padding > 0)
+                    {
+                        // TODO Append(' ', padding);
+                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
+                        bufferWriter.Advance(padding);
+                    }
+
+                    ZString.AppendChars(ref bufferWriter, s.AsSpan());
+                }
+                else
+                {
+                    Span<byte> s = stackalloc byte[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
+
+                    if (!FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
+                    {
+                        s = stackalloc byte[s.Length * 2];
+                        if (!FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
+                        {
+                            ExceptionUtil.ThrowArgumentException(argName);
+                        }
+                    }
+
+                    int padding = width - charsWritten;
+                    if (padding > 0)
+                    {
+                        // TODO Append(' ', padding);
+                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
+                        bufferWriter.Advance(padding);
+                    }
+
+                    s.CopyTo(bufferWriter.GetSpan(charsWritten));
+                    bufferWriter.Advance(charsWritten);
+                }
+            }
+        }
+    
     }
 }

--- a/src/ZString/ZString.Utf8Format.tt
+++ b/src/ZString/ZString.Utf8Format.tt
@@ -63,7 +63,7 @@ namespace Cysharp.Text
                     {
 <# for(var j = 0; j < i; j++) { #>
                         case <#= j #>:
-                            Utf8FormatInternal(bufferWriter, arg<#= j + 1 #>, indexParse.Alignment, writeFormat, nameof(arg<#= j + 1 #>));
+                            Utf8FormatHelper.FormatTo(ref bufferWriter, arg<#= j + 1 #>, indexParse.Alignment, writeFormat, nameof(arg<#= j + 1 #>));
                             continue;
 <# } #>
                         default:
@@ -103,79 +103,6 @@ namespace Cysharp.Text
                 }
             }
         }
-
 <# } #>
-
-        static void Utf8FormatInternal<T>(IBufferWriter<byte> bufferWriter, T arg, int width, StandardFormat format, string argName)
-        {
-            if (width <= 0) // leftJustify
-            {
-                width *= -1;
-
-                var buffer = bufferWriter.GetSpan();
-
-                if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out var written, format))
-                {
-                    bufferWriter.Advance(0);
-                    buffer = bufferWriter.GetSpan(Math.Max(buffer.Length + 1, written));
-
-                    if (!FormatterCache<T>.TryFormatDelegate(arg, buffer, out written, format))
-                    {
-                        ExceptionUtil.ThrowArgumentException(argName);
-                    }
-                }
-
-                bufferWriter.Advance(written);
-
-                int padding = width - written;
-                if (width > 0 && padding > 0)
-                {
-                    // TODO Append(' ', padding);
-                    bufferWriter.GetSpan(padding).Fill((byte)' ');  // TODO Fill Method is too slow.
-                    bufferWriter.Advance(padding);
-                }
-            }
-            else // rightJustify
-            {
-                if (typeof(T) == typeof(string))
-                {
-                    var s = Unsafe.As<string>(arg);
-                    int padding = width - s.Length;
-                    if (padding > 0)
-                    {
-                        // TODO Append(' ', padding);
-                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
-                        bufferWriter.Advance(padding);
-                    }
-
-                    ZString.AppendChars(ref bufferWriter, s.AsSpan());
-                }
-                else
-                {
-                    Span<byte> s = stackalloc byte[typeof(T).IsValueType ? Unsafe.SizeOf<T>() * 8 : 1024];
-
-                    if (!FormatterCache<T>.TryFormatDelegate(arg, s, out var charsWritten, format))
-                    {
-                        s = stackalloc byte[s.Length * 2];
-                        if (!FormatterCache<T>.TryFormatDelegate(arg, s, out charsWritten, format))
-                        {
-                            ExceptionUtil.ThrowArgumentException(argName);
-                        }
-                    }
-
-                    int padding = width - charsWritten;
-                    if (padding > 0)
-                    {
-                        // TODO Append(' ', padding);
-                        bufferWriter.GetSpan(padding).Fill((byte)' '); // TODO Fill Method is too slow.
-                        bufferWriter.Advance(padding);
-                    }
-
-                    s.CopyTo(bufferWriter.GetSpan(charsWritten));
-                    bufferWriter.Advance(charsWritten);
-                }
-            }
-        }
-    
     }
 }

--- a/src/ZString/ZString.cs
+++ b/src/ZString/ZString.cs
@@ -11,6 +11,14 @@ namespace Cysharp.Text
     {
         static Encoding UTF8NoBom = new UTF8Encoding(false);
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AppendChars<TBufferWriter>(ref TBufferWriter sb, ReadOnlySpan<char> chars)
+            where TBufferWriter : System.Buffers.IBufferWriter<byte>
+        {
+            var span = sb.GetSpan(UTF8NoBom.GetMaxByteCount(chars.Length));
+            sb.Advance(UTF8NoBom.GetBytes(chars, span));
+        }
+
         /// <summary>Create the Utf16 string StringBuilder.</summary>
         public static Utf16ValueStringBuilder CreateStringBuilder()
         {

--- a/src/ZString/ZString.csproj
+++ b/src/ZString/ZString.csproj
@@ -31,6 +31,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <None Update="FormatHelper.tt">
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>FormatHelper.cs</LastGenOutput>
+        </None>
         <None Update="PreparedFormat.tt">
             <Generator>TextTemplatingFileGenerator</Generator>
             <LastGenOutput>PreparedFormat.cs</LastGenOutput>
@@ -94,6 +98,11 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Compile Update="FormatHelper.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>FormatHelper.tt</DependentUpon>
+        </Compile>
         <Compile Update="PreparedFormat.cs">
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>

--- a/tests/ZString.Tests/CompositeFormatTest.cs
+++ b/tests/ZString.Tests/CompositeFormatTest.cs
@@ -1,0 +1,127 @@
+using Cysharp.Text;
+using FluentAssertions;
+using System;
+using System.Buffers;
+using System.Text;
+using Xunit;
+using static FluentAssertions.FluentActions;
+
+using static ZStringTests.FormatTest;
+namespace ZStringTests
+{
+    public class CompositeFormatTest
+    {
+        [Theory]
+        [InlineData("{1}")]
+        [InlineData("{-0}")]
+        [InlineData("{-1}")]
+        [InlineData("}")]
+        [InlineData("{")]
+        [InlineData("{}")]
+        [InlineData("{A}")]
+        [InlineData("{1A}")]
+        [InlineData("{0x0}")]
+        [InlineData("{\uff11}")] // Full-Width One
+        [InlineData("{ }")]
+        [InlineData("{ 1}")]
+        [InlineData("{0 0}")]
+        [InlineData("{0+0}")]
+        [InlineData("{0")]
+        [InlineData("{foo")]
+        [InlineData("{{0}")]
+        [InlineData("{{{0")]
+        [InlineData("0}")]
+        [InlineData("bar}")]
+        [InlineData("{0}}")]
+        [InlineData("0}}}")]
+        [InlineData("{:0}")]
+        [InlineData("{0{}")]
+        [InlineData("{0{1}}")]
+        [InlineData("{,0}")]
+        [InlineData("{ 0,0}")]
+        [InlineData("{,-0}")]
+        [InlineData("{0,-}")]
+        [InlineData("{0,- 0}")]
+        [InlineData("{0,--0}")]
+        [InlineData("{:}")]
+        [InlineData("{,:}")]
+        [InlineData(" { , : } ")]
+        [InlineData("{:,}")]
+        [InlineData("{::}")]
+        [InlineData("{,,}")]
+        [InlineData(@"{\0}")]
+        [InlineData(@"{0\,0}")]
+        [InlineData(@"{0,0\:}")]
+        [InlineData(@"{0:\}}")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "<•Û—¯’†>")]
+        public void IncorrectFormat(string format)
+        {
+            var value = 9999;
+            var expected = CatchException(() => string.Format(format, value));
+            var actual = CatchException(() => ZString.Format(format, value));
+
+            expected.Should().NotBeNull(); // test miss!
+            actual.Should().BeOfType(expected.GetType());
+
+            Exception CatchException(Func<string> func)
+            {
+                try
+                {
+                    _ = func();
+                    return null;
+                }
+                catch (Exception e)
+                {
+                    return e;
+                }
+            }
+        }
+
+        [Fact]
+        public void AlignmentComponentInt()
+        {
+            Test("{1,-1}{0,1}", Int64.MinValue, Int64.MaxValue);
+            Test("{0,1}{1,-1}", 1, 1);
+            Test("{0,10}{1,-10}", 1, 1);
+        }
+        [Fact]
+        public void AlignmentComponentString()
+        {
+            Test("{1,0}{0,0}", "right", "left");
+            Test("{0,3}{1,-3}", "Foo", "Foo");
+            Test("{0,4}{1,-4}", "Foo", "Foo");
+        }
+        [Fact]
+        public void AlignmentComponent()
+        {
+            Test("{1,-" + 1000 + "}{0," + 1000 + "}", 
+                "", Int64.MaxValue);
+            var guid = Guid.NewGuid();
+            Test(testUtf8: false, "{0,10:X}{{0}}{1,-10:c}", Guid.NewGuid(), DateTime.Now.TimeOfDay.Negate());
+
+            string[] names = { "Adam", "Bridgette", "Carla", "Daniel", "Ebenezer", "Francine", "George" };
+            decimal[] hours = { 40, 6.667m, 40.39m, 82, 40.333m, 80, 16.75m };
+
+            for (int ctr = 0; ctr < names.Length; ctr++)
+                Test("{0,-20} {1,5:F}", names[ctr], hours[ctr]);
+        }
+
+
+        [Fact]
+        public void Spaces()
+        {
+            var format = "Prime numbers less than 10: {00 , 01 }, {01  ,02  }, {2 ,3 :D }, {3  ,4: X }";
+            var expected = string.Format(format, 2, 3, 5, 7);
+            var actual = ZString.Format(format, 2, 3, 5, 7);
+            actual.Should().Be(expected);
+
+        }
+
+        [Fact]
+        public void CompsiteFormats()
+        {
+            Test("{{Name = {0}, {1:f}({1:E})}}", "Fred", 500_0000_0000_0000m);
+        }
+
+    }
+}

--- a/tests/ZString.Tests/FormatTest.cs
+++ b/tests/ZString.Tests/FormatTest.cs
@@ -10,13 +10,19 @@ namespace ZStringTests
 {
     public class FormatTest
     {
-        void Test<T0, T1>(string format, T0 t0, T1 t1)
+        internal static void Test<T0, T1>(string format, T0 t0, T1 t1)
+        {
+            Test(true, format, t0, t1);
+        }
+
+        internal static void Test<T0, T1>(bool testUtf8, string format, T0 t0, T1 t1)
         {
             {
                 var actual = ZString.Format(format, t0, t1);
                 var expected = string.Format(format, t0, t1);
                 actual.Should().Be(expected);
             }
+            if (testUtf8)
             {
                 var sb = ZString.CreateUtf8StringBuilder();
                 sb.AppendFormat(format, t0, t1);
@@ -31,6 +37,7 @@ namespace ZStringTests
                 var expected = string.Format(format, t0, t1);
                 actual.Should().Be(expected);
             }
+            if (testUtf8)
             {
                 var sb = ZString.PrepareUtf8<T0, T1>(format);
                 var actual = sb.Format(t0, t1);
@@ -39,12 +46,53 @@ namespace ZStringTests
             }
 
             // Direct
+            if (testUtf8)
             {
 #if NETCOREAPP3_1
                 var writer = new ArrayBufferWriter<byte>();
                 ZString.Utf8Format(writer, format, t0, t1);
                 var actual = Encoding.UTF8.GetString(writer.WrittenSpan);
                 var expected = string.Format(format, t0, t1);
+                actual.Should().Be(expected);
+#endif
+            }
+        }
+
+        void Test<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+        {
+            {
+                var actual = ZString.Format(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                var expected = string.Format(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                actual.Should().Be(expected);
+            }
+            {
+                var sb = ZString.CreateUtf8StringBuilder();
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                var actual = sb.ToString();
+                var expected = string.Format(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                actual.Should().Be(expected);
+            }
+
+            // Prepare
+            {
+                var actual = ZString.PrepareUtf16<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(format).Format(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                var expected = string.Format(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                actual.Should().Be(expected);
+            }
+            {
+                var sb = ZString.PrepareUtf8<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(format);
+                var actual = sb.Format(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                var expected = string.Format(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                actual.Should().Be(expected);
+            }
+
+            // Direct
+            {
+#if NETCOREAPP3_1
+                var writer = new ArrayBufferWriter<byte>();
+                ZString.Utf8Format(writer, format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                var actual = Encoding.UTF8.GetString(writer.WrittenSpan);
+                var expected = string.Format(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
                 actual.Should().Be(expected);
 #endif
             }
@@ -87,6 +135,21 @@ namespace ZStringTests
         }
 
         [Fact]
+        public void EmptyFormatString()
+        {
+            // UtfFormatter Deny space only
+            Test(false, "{0:}{1: }", 100, 200);
+        }
+
+        [Fact]
+        public void MaximumFormat()
+        {
+            Test("abc{0}de{1}f{2}g{3}h{4}i{5}{6}{7}{8}{9}{10}{11}{12}{13}{14}{15}z",
+                100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1100, 1200, 1300, 1400, 1500, 1600);
+        }
+
+
+        [Fact]
         public void Nullable()
         {
             Test("abc{0}def{1}ghi", (int?)100, (int?)1);
@@ -99,6 +162,7 @@ namespace ZStringTests
         public void Comment()
         {
             Test("abc{{0}}def{1}ghi", 100, 200);
+            Test("}}{{{0}{{}}{1}{{", 123, 456);
         }
 
         [Fact]


### PR DESCRIPTION
# BCL-Compatibility

The format of ZString has some incompatibility with BCL.
The main missing piece is the "Alignment Component".
There are also differences in the handling of whitespace and incorrect formatting.

Some of the cases are listed below.


| Format String                                                                      | `String.Format`                             | `ZString.Format`                |
| ---------------------------------------------------------------------------------- | ------------------------------------------- | ------------------------------- |
| `Test("{0,10:X}{{0}}{1,-10:c}", Guid.NewGuid(), DateTime.Now.TimeOfDay.Negate());` | Accept                                      | throws FormatException          |
| `Test("{1,-1}{0,1}", Int64.MinValue, Int64.MaxValue);`                             | `"9223372036854775807-9223372036854775808"` | `"-1-1"`                        |
| `Test("{00 , 01 }, {01  ,02  }, {2 ,3 :D }, {3  ,4: X }", 2, 3, 5, 7)`             | Accept                                      | throws FormatException          |
| `Test("}")`                                                                        | throws FormatException                      | throws IndexOutOfRangeException |
| `Test("{ 0,0}, 9999")`                                                             | throws FormatException                      | `"9999"`                        |

I have added a test in CompositeFormatTest.cs that you can check out.

# Performance

I've refactored the formatting parsing process.
As a side effect, it makes most of the parsing process about 20% faster. (compared to ver 2.2.0)

However, in the case of short format string (like `x:{0}, y:{1}`), Utf16PreparedFormat and Utf8PreparedFormat are about 20% slower.
I have optimized the PreparedFormat class, but Utf16PreparedFormat is still slow.

Format is acceptable because the impact is limited.

## FormatBenchmark.cs

|                          Method |         FormatString |      Mean |    Error |   StdDev | Ratio | RatioSD | Code Size |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |--------------------- |----------:|---------:|---------:|------:|--------:|----------:|-------:|------:|------:|----------:|
|                         Format_ | This (...)orld. [62] | 208.25 ns | 2.284 ns | 2.136 ns |  1.00 |    0.00 |    3147 B | 0.0181 |     - |     - |     152 B |
|                         FormatN | This (...)orld. [62] | 166.63 ns | 2.186 ns | 2.045 ns |  0.80 |    0.01 |    4172 B | 0.0181 |     - |     - |     152 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|      CreateUtf16PreparedFormat_ | This (...)orld. [62] | 303.47 ns | 4.553 ns | 4.259 ns |  1.00 |    0.00 |    2796 B | 0.0820 |     - |     - |     688 B |
|      CreateUtf16PreparedFormatN | This (...)orld. [62] | 297.62 ns | 5.283 ns | 4.942 ns |  0.98 |    0.01 |    2030 B | 0.0658 |     - |     - |     552 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|       CreateUtf8PreparedFormat_ | This (...)orld. [62] | 300.89 ns | 6.018 ns | 5.629 ns |  1.00 |    0.00 |    2799 B | 0.0820 |     - |     - |     688 B |
|       CreateUtf8PreparedFormatN | This (...)orld. [62] | 338.32 ns | 5.217 ns | 4.880 ns |  1.12 |    0.03 |    3430 B | 0.0849 |     - |     - |     712 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|            Utf16PreparedFormat_ | This (...)orld. [62] |  79.30 ns | 1.162 ns | 1.087 ns |  1.00 |    0.00 |    2597 B | 0.0181 |     - |     - |     152 B |
|            Utf16PreparedFormatN | This (...)orld. [62] |  96.11 ns | 1.342 ns | 1.255 ns |  1.21 |    0.02 |    2188 B | 0.0181 |     - |     - |     152 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|             Utf8PreparedFormat_ | This (...)orld. [62] | 167.63 ns | 2.481 ns | 2.321 ns |  1.00 |    0.00 |    2569 B | 0.0181 |     - |     - |     152 B |
|             Utf8PreparedFormatN | This (...)orld. [62] | 137.85 ns | 2.213 ns | 2.070 ns |  0.82 |    0.02 |    2356 B | 0.0181 |     - |     - |     152 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
| Utf16StringBuilderAppendFormat_ | This (...)orld. [62] | 216.73 ns | 0.727 ns | 0.680 ns |  1.00 |    0.00 |    7425 B |      - |     - |     - |         - |
| Utf16StringBuilderAppendFormatN | This (...)orld. [62] | 162.42 ns | 1.610 ns | 1.506 ns |  0.75 |    0.01 |    7393 B |      - |     - |     - |         - |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|  Utf8StringBuilderAppendFormat_ | This (...)orld. [62] | 245.23 ns | 0.942 ns | 0.835 ns |  1.00 |    0.00 |    7856 B |      - |     - |     - |         - |
|  Utf8StringBuilderAppendFormatN | This (...)orld. [62] | 229.33 ns | 0.944 ns | 0.883 ns |  0.93 |    0.00 |   10714 B |      - |     - |     - |         - |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|                         Format_ |         x:{0}, y:{1} | 133.78 ns | 1.151 ns | 1.076 ns |  1.00 |    0.00 |    3147 B | 0.0057 |     - |     - |      48 B |
|                         FormatN |         x:{0}, y:{1} |  99.33 ns | 1.070 ns | 1.000 ns |  0.74 |    0.01 |    4172 B | 0.0057 |     - |     - |      48 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|      CreateUtf16PreparedFormat_ |         x:{0}, y:{1} | 206.94 ns | 2.647 ns | 2.476 ns |  1.00 |    0.00 |    2796 B | 0.0448 |     - |     - |     376 B |
|      CreateUtf16PreparedFormatN |         x:{0}, y:{1} | 126.35 ns | 2.426 ns | 2.269 ns |  0.61 |    0.01 |    2030 B | 0.0372 |     - |     - |     312 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|       CreateUtf8PreparedFormat_ |         x:{0}, y:{1} | 203.51 ns | 1.199 ns | 1.122 ns |  1.00 |    0.00 |    2799 B | 0.0448 |     - |     - |     376 B |
|       CreateUtf8PreparedFormatN |         x:{0}, y:{1} | 169.32 ns | 2.718 ns | 2.542 ns |  0.83 |    0.01 |    3430 B | 0.0420 |     - |     - |     352 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|            Utf16PreparedFormat_ |         x:{0}, y:{1} |  69.21 ns | 0.898 ns | 0.840 ns |  1.00 |    0.00 |    2597 B | 0.0057 |     - |     - |      48 B |
|            Utf16PreparedFormatN |         x:{0}, y:{1} |  81.91 ns | 1.049 ns | 0.982 ns |  1.18 |    0.02 |    2188 B | 0.0057 |     - |     - |      48 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|             Utf8PreparedFormat_ |         x:{0}, y:{1} | 126.13 ns | 0.971 ns | 0.860 ns |  1.00 |    0.00 |    2569 B | 0.0057 |     - |     - |      48 B |
|             Utf8PreparedFormatN |         x:{0}, y:{1} | 111.22 ns | 0.655 ns | 0.613 ns |  0.88 |    0.01 |    2356 B | 0.0057 |     - |     - |      48 B |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
| Utf16StringBuilderAppendFormat_ |         x:{0}, y:{1} | 144.91 ns | 0.756 ns | 0.707 ns |  1.00 |    0.00 |    7276 B |      - |     - |     - |         - |
| Utf16StringBuilderAppendFormatN |         x:{0}, y:{1} | 102.43 ns | 0.460 ns | 0.431 ns |  0.71 |    0.00 |    7393 B |      - |     - |     - |         - |
|                                 |                      |           |          |          |       |         |           |        |       |       |           |
|  Utf8StringBuilderAppendFormat_ |         x:{0}, y:{1} | 175.73 ns | 0.787 ns | 0.736 ns |  1.00 |    0.00 |    7856 B |      - |     - |     - |         - |
|  Utf8StringBuilderAppendFormatN |         x:{0}, y:{1} | 147.53 ns | 0.988 ns | 0.876 ns |  0.84 |    0.01 |   10549 B |      - |     - |     - |         - |

```ini
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=3.1.302
  [Host]     : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT
  DefaultJob : .NET Core 3.1.6 (CoreCLR 4.700.20.26901, CoreFX 4.700.20.31603), X64 RyuJIT
```

## BuiltinTypesBenchmark.cs

|                          Method |       Mean |    Error |   StdDev | Ratio | Code Size |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------------------- |-----------:|---------:|---------:|------:|----------:|-------:|-------:|------:|----------:|
|                         Format_ | 2,871.2 ns | 19.09 ns | 17.86 ns |  1.00 |     952 B | 0.0648 |      - |     - |     560 B |
|                         FormatN | 2,337.8 ns | 15.88 ns | 14.85 ns |  0.81 |     952 B | 0.0648 |      - |     - |     552 B |
|                                 |            |          |          |       |           |        |        |       |           |
|      CreateUtf16PreparedFormat_ | 1,207.0 ns | 17.42 ns | 16.29 ns |  1.00 |     200 B | 0.3700 | 0.0038 |     - |    3104 B |
|      CreateUtf16PreparedFormatN |   536.0 ns |  8.16 ns |  7.63 ns |  0.44 |     159 B | 0.1965 | 0.0010 |     - |    1648 B |
|                                 |            |          |          |       |           |        |        |       |           |
|       CreateUtf8PreparedFormat_ | 1,228.2 ns | 19.72 ns | 18.45 ns |  1.00 |     203 B | 0.3700 | 0.0038 |     - |    3104 B |
|       CreateUtf8PreparedFormatN |   886.5 ns | 10.00 ns |  8.35 ns |  0.72 |     194 B | 0.2699 | 0.0019 |     - |    2264 B |
|                                 |            |          |          |       |           |        |        |       |           |
|            Utf16PreparedFormat_ | 2,349.2 ns | 17.56 ns | 16.42 ns |  1.00 |     944 B | 0.0648 |      - |     - |     560 B |
|            Utf16PreparedFormatN | 2,283.9 ns | 18.38 ns | 17.19 ns |  0.97 |     944 B | 0.0648 |      - |     - |     560 B |
|                                 |            |          |          |       |           |        |        |       |           |
|             Utf8PreparedFormat_ | 1,575.2 ns | 10.36 ns |  9.69 ns |  1.00 |     961 B | 0.0591 |      - |     - |     504 B |
|             Utf8PreparedFormatN | 1,403.4 ns | 11.02 ns | 10.31 ns |  0.89 |     961 B | 0.0591 |      - |     - |     504 B |
|                                 |            |          |          |       |           |        |        |       |           |
| Utf16StringBuilderAppendFormat_ | 2,814.9 ns | 10.21 ns |  9.55 ns |  1.00 |    4686 B | 0.0076 |      - |     - |      72 B |
| Utf16StringBuilderAppendFormatN | 2,274.3 ns | 18.23 ns | 16.16 ns |  0.81 |    5571 B | 0.0076 |      - |     - |      72 B |
|                                 |            |          |          |       |           |        |        |       |           |
|  Utf8StringBuilderAppendFormat_ | 2,017.8 ns | 16.70 ns | 15.62 ns |  1.00 |    5186 B |      - |      - |     - |      24 B |
|  Utf8StringBuilderAppendFormatN | 1,740.7 ns | 10.89 ns | 10.19 ns |  0.86 |    6096 B | 0.0019 |      - |     - |      24 B |
