### PR TITLE
Optimize for bool type

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
@@ -126,6 +126,10 @@ namespace Cysharp.Text
             {
                 return CreateNullableFormatter<System.Guid>();
             }
+            if (type == typeof(System.Boolean?))
+            {
+                return CreateNullableFormatter<System.Boolean>();
+            }
             if (type == typeof(System.IntPtr))
             {
                 // ignore format

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -512,6 +512,9 @@ namespace Cysharp.Text
         /// <summary>Converts the value of this instance to a System.String.</summary>
         public override string ToString()
         {
+            if (index == 0)
+                return string.Empty;
+
             return new string(buffer, 0, index);
         }
 

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
@@ -68,6 +68,10 @@ namespace Cysharp.Text
             {
                 return new TryFormat<System.Guid>((System.Guid x, Span<byte> dest, out int written, StandardFormat format) => Utf8Formatter.TryFormat(x, dest, out written, format));
             }
+            if (type == typeof(System.Boolean))
+            {
+                return new TryFormat<System.Boolean>((System.Boolean x, Span<byte> dest, out int written, StandardFormat format) => Utf8Formatter.TryFormat(x, dest, out written, format));
+            }
             if (type == typeof(System.Byte?))
             {
                 return CreateNullableFormatter<System.Byte>();
@@ -127,6 +131,10 @@ namespace Cysharp.Text
             if (type == typeof(System.Guid?))
             {
                 return CreateNullableFormatter<System.Guid>();
+            }
+            if (type == typeof(System.Boolean?))
+            {
+                return CreateNullableFormatter<System.Boolean>();
             }
             if (type == typeof(System.IntPtr))
             {

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
@@ -52,6 +52,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.DateTime value)
@@ -97,6 +98,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.DateTimeOffset value)
@@ -142,6 +144,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Decimal value)
@@ -187,6 +190,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Double value)
@@ -232,6 +236,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Int16 value)
@@ -277,6 +282,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Int32 value)
@@ -322,6 +328,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Int64 value)
@@ -367,6 +374,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.SByte value)
@@ -412,6 +420,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Single value)
@@ -457,6 +466,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.TimeSpan value)
@@ -502,6 +512,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.UInt16 value)
@@ -547,6 +558,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.UInt32 value)
@@ -592,6 +604,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.UInt64 value)
@@ -637,6 +650,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Guid value)
@@ -682,5 +696,52 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
+        /// <summary>Appends the string representation of a specified value to this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(System.Boolean value)
+        {
+            if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out var written))
+            {
+                Grow(written);
+                if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out written))
+                {
+                    ThrowArgumentException(nameof(value));
+                }
+            }
+            index += written;
+        }
+
+        /// <summary>Appends the string representation of a specified value to this instance with numeric format strings.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(System.Boolean value, StandardFormat format)
+        {
+            if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out var written, format))
+            {
+                Grow(written);
+                if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out written, format))
+                {
+                    ThrowArgumentException(nameof(value));
+                }
+            }
+            index += written;
+        }
+
+        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(System.Boolean value)
+        {
+            Append(value);
+            AppendLine();
+        }
+
+        /// <summary>Appends the string representation of a specified value with numeric format strings followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(System.Boolean value, StandardFormat format)
+        {
+            Append(value, format);
+            AppendLine();
+        }
+
     }
 }

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
@@ -313,6 +313,9 @@ namespace Cysharp.Text
         /// <summary>Encode the innner utf8 buffer to a System.String.</summary>
         public override string ToString()
         {
+            if (index == 0)
+                return string.Empty;
+
             return UTF8NoBom.GetString(buffer, 0, index);
         }
 

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.Concat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.Concat.cs
@@ -7,6 +7,11 @@ namespace Cysharp.Text
         /// <summary>Concatenates the string representation of some specified objects.</summary>
         public static string Concat<T1>(T1 arg1)
         {
+            if (typeof(T1) == typeof(string))
+            {
+                return (arg1 != null) ? Unsafe.As<string>(arg1) : string.Empty;
+            }
+
             var sb = new Utf16ValueStringBuilder(true);
             try
             {

--- a/src/ZString/T4Common.t4
+++ b/src/ZString/T4Common.t4
@@ -41,4 +41,6 @@
         typeof(Guid),
         // typeof(Version),
     };
+    
+    var utf8spanFormattables = spanFormattables.Append(typeof(bool));
 #>

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.cs
@@ -126,6 +126,10 @@ namespace Cysharp.Text
             {
                 return CreateNullableFormatter<System.Guid>();
             }
+            if (type == typeof(System.Boolean?))
+            {
+                return CreateNullableFormatter<System.Boolean>();
+            }
             if (type == typeof(System.IntPtr))
             {
                 // ignore format

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.tt
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.CreateFormatter.tt
@@ -57,7 +57,7 @@ namespace Cysharp.Text
                 return new TryFormat<<#= t.FullName #>>((<#= t.FullName #> x, Span<char> dest, out int written, ReadOnlySpan<char> format) => x.TryFormat(dest, out written, format));
             }
 <# } #>
-<# foreach(var t in spanFormattables) { #>
+<# foreach(var t in spanFormattables.Append(typeof(bool))) { #>
             if (type == typeof(<#= t.FullName #>?))
             {
                 return CreateNullableFormatter<<#= t.FullName #>>();

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -512,6 +512,9 @@ namespace Cysharp.Text
         /// <summary>Converts the value of this instance to a System.String.</summary>
         public override string ToString()
         {
+            if (index == 0)
+                return string.Empty;
+
             return new string(buffer, 0, index);
         }
 

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.cs
@@ -68,6 +68,10 @@ namespace Cysharp.Text
             {
                 return new TryFormat<System.Guid>((System.Guid x, Span<byte> dest, out int written, StandardFormat format) => Utf8Formatter.TryFormat(x, dest, out written, format));
             }
+            if (type == typeof(System.Boolean))
+            {
+                return new TryFormat<System.Boolean>((System.Boolean x, Span<byte> dest, out int written, StandardFormat format) => Utf8Formatter.TryFormat(x, dest, out written, format));
+            }
             if (type == typeof(System.Byte?))
             {
                 return CreateNullableFormatter<System.Byte>();
@@ -127,6 +131,10 @@ namespace Cysharp.Text
             if (type == typeof(System.Guid?))
             {
                 return CreateNullableFormatter<System.Guid>();
+            }
+            if (type == typeof(System.Boolean?))
+            {
+                return CreateNullableFormatter<System.Boolean>();
             }
             if (type == typeof(System.IntPtr))
             {

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.tt
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.CreateFormatter.tt
@@ -15,13 +15,13 @@ namespace Cysharp.Text
     {
         static object CreateFormatter(Type type)
         {
-<# foreach(var t in spanFormattables) { #>
+<# foreach(var t in utf8spanFormattables) { #>
             if (type == typeof(<#= t.FullName #>))
             {
                 return new TryFormat<<#= t.FullName #>>((<#= t.FullName #> x, Span<byte> dest, out int written, StandardFormat format) => Utf8Formatter.TryFormat(x, dest, out written, format));
             }
 <# } #>
-<# foreach(var t in spanFormattables) { #>
+<# foreach(var t in utf8spanFormattables) { #>
             if (type == typeof(<#= t.FullName #>?))
             {
                 return CreateNullableFormatter<<#= t.FullName #>>();

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.cs
@@ -52,6 +52,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.DateTime value)
@@ -97,6 +98,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.DateTimeOffset value)
@@ -142,6 +144,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Decimal value)
@@ -187,6 +190,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Double value)
@@ -232,6 +236,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Int16 value)
@@ -277,6 +282,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Int32 value)
@@ -322,6 +328,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Int64 value)
@@ -367,6 +374,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.SByte value)
@@ -412,6 +420,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Single value)
@@ -457,6 +466,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.TimeSpan value)
@@ -502,6 +512,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.UInt16 value)
@@ -547,6 +558,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.UInt32 value)
@@ -592,6 +604,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.UInt64 value)
@@ -637,6 +650,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(System.Guid value)
@@ -682,5 +696,52 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
+        /// <summary>Appends the string representation of a specified value to this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(System.Boolean value)
+        {
+            if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out var written))
+            {
+                Grow(written);
+                if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out written))
+                {
+                    ThrowArgumentException(nameof(value));
+                }
+            }
+            index += written;
+        }
+
+        /// <summary>Appends the string representation of a specified value to this instance with numeric format strings.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(System.Boolean value, StandardFormat format)
+        {
+            if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out var written, format))
+            {
+                Grow(written);
+                if(!Utf8Formatter.TryFormat(value, buffer.AsSpan(index), out written, format))
+                {
+                    ThrowArgumentException(nameof(value));
+                }
+            }
+            index += written;
+        }
+
+        /// <summary>Appends the string representation of a specified value followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(System.Boolean value)
+        {
+            Append(value);
+            AppendLine();
+        }
+
+        /// <summary>Appends the string representation of a specified value with numeric format strings followed by the default line terminator to the end of this instance.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void AppendLine(System.Boolean value, StandardFormat format)
+        {
+            Append(value, format);
+            AppendLine();
+        }
+
     }
 }

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.tt
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.SpanFormattableAppend.tt
@@ -14,7 +14,7 @@ namespace Cysharp.Text
 {
     public partial struct Utf8ValueStringBuilder
     {
-<# foreach(var t in spanFormattables) { #>
+<# foreach(var t in utf8spanFormattables) { #>
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(<#= t.FullName #> value)
@@ -60,6 +60,7 @@ namespace Cysharp.Text
             Append(value, format);
             AppendLine();
         }
+
 <# } #>
     }
 }

--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -313,6 +313,9 @@ namespace Cysharp.Text
         /// <summary>Encode the innner utf8 buffer to a System.String.</summary>
         public override string ToString()
         {
+            if (index == 0)
+                return string.Empty;
+
             return UTF8NoBom.GetString(buffer, 0, index);
         }
 

--- a/src/ZString/ZString.Concat.cs
+++ b/src/ZString/ZString.Concat.cs
@@ -7,6 +7,11 @@ namespace Cysharp.Text
         /// <summary>Concatenates the string representation of some specified objects.</summary>
         public static string Concat<T1>(T1 arg1)
         {
+            if (typeof(T1) == typeof(string))
+            {
+                return (arg1 != null) ? Unsafe.As<string>(arg1) : string.Empty;
+            }
+
             var sb = new Utf16ValueStringBuilder(true);
             try
             {

--- a/src/ZString/ZString.Concat.tt
+++ b/src/ZString/ZString.Concat.tt
@@ -15,6 +15,13 @@ namespace Cysharp.Text
         /// <summary>Concatenates the string representation of some specified objects.</summary>
         public static string Concat<<#= CreateTypeArgument(i) #>>(<#= CreateParameters(i) #>)
         {
+<# if(i == 1) { #>
+            if (typeof(T1) == typeof(string))
+            {
+                return (arg1 != null) ? Unsafe.As<string>(arg1) : string.Empty;
+            }
+
+<# } #>
             var sb = new Utf16ValueStringBuilder(true);
             try
             {

--- a/tests/ZString.Tests/Primitives.cs
+++ b/tests/ZString.Tests/Primitives.cs
@@ -205,5 +205,29 @@ namespace ZStringTests
                 sb1.ToString().Should().Be(sb5.ToString());
             }
         }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void BoolTest(bool x)
+        {
+            using (var sb1 = ZString.CreateStringBuilder())
+            using (var sb2 = ZString.CreateUtf8StringBuilder())
+            using (var sb3 = ZString.CreateStringBuilder())
+            using (var sb4 = ZString.CreateUtf8StringBuilder())
+            {
+                var sb5 = new StringBuilder();
+                sb1.Append(x);
+                sb2.Append(x);
+                sb3.Append(x);
+                sb4.Append(x);
+                sb5.Append(x);
+
+                sb1.ToString().Should().Be(sb2.ToString());
+                sb1.ToString().Should().Be(sb3.ToString());
+                sb1.ToString().Should().Be(sb4.ToString());
+                sb1.ToString().Should().Be(sb5.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
`Boolean.ToString()` returns a constant so there is no allocation, but there is a cost to convert it to UTF8.
That's why I used `Utf8Formatter.TryFormat`.

Other minor optimizations include.