### PR TITLE
chore: replace set-env to ENV FILE $GITHUB_ENV

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -3,7 +3,7 @@ name: Build-Debug
 on:
   push:
     branches:
-      - "**"
+      - "master"
     tags:
       - "!*" # not a tag push
   pull_request:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 3.1.x
       - run: dotnet build src/ZString -c Debug
       - run: dotnet test tests/ZString.Tests -c Debug < /dev/null
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,9 +16,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: 3.1.x
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - run: dotnet build src/ZString -c Release -p:Version=${{ env.GIT_TAG }}
       - run: dotnet test tests/ZString.Tests -c Release --no-build
       - run: dotnet pack ./src/ZString/ZString.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }}
@@ -28,11 +28,11 @@ jobs:
         with:
           name: nuget
           path: ./src/ZString/bin/Release/ZString.${{ env.GIT_TAG }}.nupkg
-      
+
   build-unity:
     strategy:
       matrix:
-        unity: ['2019.3.9f1']
+        unity: ["2019.3.9f1"]
         include:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
@@ -49,7 +49,7 @@ jobs:
       - run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
 
       # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
       # Execute scripts: Export Package
       - name: Export unitypackage
@@ -72,34 +72,34 @@ jobs:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
     steps:
-    # setup dotnet for nuget push
-    - uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.101
-    # set release tag(*.*.*) to env.GIT_TAG
-    - run: echo ::set-env name=GIT_TAG::${GITHUB_REF#refs/tags/}
+      # setup dotnet for nuget push
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.x
+      # set release tag(*.*.*) to env.GIT_TAG
+      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-    # Create Releases
-    - uses: actions/create-release@v1
-      id: create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Ver.${{ github.ref }}
+      # Create Releases
+      - uses: actions/create-release@v1
+        id: create_release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Ver.${{ github.ref }}
 
-    # Download (All) Artifacts to current directory
-    - uses: actions/download-artifact@v2-preview
+      # Download (All) Artifacts to current directory
+      - uses: actions/download-artifact@v2-preview
 
-    # Upload to NuGet
-    - run: dotnet nuget push "./nuget/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
+      # Upload to NuGet
+      - run: dotnet nuget push "./nuget/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
 
-    # Upload to Releases(unitypackage)
-    - uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./ZString.Unity.${{ env.GIT_TAG }}.unitypackage/ZString.Unity.${{ env.GIT_TAG }}.unitypackage
-        asset_name: ZString.Unity.${{ env.GIT_TAG }}.unitypackage
-        asset_content_type: application/octet-stream
+      # Upload to Releases(unitypackage)
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./ZString.Unity.${{ env.GIT_TAG }}.unitypackage/ZString.Unity.${{ env.GIT_TAG }}.unitypackage
+          asset_name: ZString.Unity.${{ env.GIT_TAG }}.unitypackage
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
* fix https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* push build on master
* use latest dotnet 3.1