### PR TITLE
chore: new unity build with unityci/editor 

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -7,9 +7,8 @@ on:
     tags:
       - "!*" # not a tag push
   pull_request:
-    types:
-      - opened
-      - synchronize
+    branches:
+      - "master"
 
 jobs:
   build-dotnet:

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -30,34 +30,30 @@ jobs:
     if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
-        unity: ["2019.3.9f1", "2020.1.0b5"]
+        unity: ["2019.3.9f1", "2019.4.13f1", "2020.1.12f1"]
         include:
           - unity: 2019.3.9f1
-            license: UNITY_2019_3
-          - unity: 2020.1.0b5
-            license: UNITY_2020_1
+            license: UNITY_LICENSE_2019
+          - unity: 2019.4.13f1
+            license: UNITY_LICENSE_2019
+          - unity: 2020.1.12f1
+            license: UNITY_LICENSE_2020
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container:
-      # with linux-il2cpp. image from https://hub.docker.com/r/gableroux/unity3d/tags
-      image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      # Ubuntu 18.04 git is too old, use ppa latest git.
-      - run: |
-          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
-          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
-      # activate Unity from manual license file(ulf)
-      - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
+      # Execute scripts: Export Package
+      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+      - name: Export unitypackage
+        uses: game-ci/unity-builder@v2.0-alpha-6
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
-      - name: Activate Unity, always returns a success. But if a subsequent run fails, the activation may have failed(if succeeded, shows `Next license update check is after` and not shows other message(like GUID != GUID). If fails not). In that case, upload the artifact's .alf file to https://license.unity3d.com/manual to get the .ulf file and set it to secrets.
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
-
-      # Execute scripts: Export Package
-      - name: Export unitypackage
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
-        working-directory: src/ZString.Unity
+        with:
+          projectPath: src/ZString.Unity
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
 
       - name: check all .meta is commited
         run: |

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   build-dotnet:
+    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]'))"
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -26,6 +27,7 @@ jobs:
       - run: dotnet test tests/ZString.Tests -c Debug < /dev/null
 
   build-unity:
+    if: "!(contains(github.event.head_commit.message, '[skip ci]') || contains(github.event.head_commit.message, '[ci skip]')) && ((github.event_name == 'push' && github.repository_owner == 'Cysharp') || startsWith(github.event.pull_request.head.label, 'Cysharp:'))"
     strategy:
       matrix:
         unity: ["2019.3.9f1", "2020.1.0b5"]
@@ -35,12 +37,17 @@ jobs:
           - unity: 2020.1.0b5
             license: UNITY_2020_1
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       # with linux-il2cpp. image from https://hub.docker.com/r/gableroux/unity3d/tags
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      - run: apt update && apt install git -y
+      # Ubuntu 18.04 git is too old, use ppa latest git.
+      - run: |
+          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
+          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
+      # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
@@ -50,6 +57,16 @@ jobs:
       # Execute scripts: Export Package
       - name: Export unitypackage
         run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+        working-directory: src/ZString.Unity
+
+      - name: check all .meta is commited
+        run: |
+          if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+            echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+            exit 1
+          else
+            echo "Great, all .meta files are commited."
+          fi
         working-directory: src/ZString.Unity
 
       # Store artifacts.

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -26,40 +26,51 @@ jobs:
       sha: ${{ steps.commit.outputs.sha }}
     steps:
       - uses: actions/checkout@v2
-      - name: before
+      - name: Output package.json (Before)
         run: cat ${{ env.TARGET_FILE}}
-      - name: update package.json to version ${{ env.GIT_TAG }}
+
+      - name: Update package.json to version ${{ env.GIT_TAG }}
         run: sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ env.GIT_TAG }}\",/" ${{ env.TARGET_FILE }}
-      - name: after
-        run: cat ${{ env.TARGET_FILE}}
+
+      - name: Check update
+        id: check_update
+        run: |
+          cat ${{ env.TARGET_FILE}}
+          git diff --exit-code || echo "::set-output name=changed::1"
+
       - name: Commit files
         id: commit
+        if: steps.check_update.outputs.changed == '1'
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git commit -m "feat: Update package.json to ${{ env.GIT_TAG }}" -a
           echo "::set-output name=sha::$(git rev-parse HEAD)"
-      - name: check sha
+
+      - name: Check sha
         run: echo "SHA ${SHA}"
         env:
           SHA: ${{ steps.commit.outputs.sha }}
-      - name: tag
+
+      - name: Create Tag
+        if: steps.check_update.outputs.changed == '1'
         run: git tag ${{ env.GIT_TAG }}
-        if: env.DRY_RUN == 'false'
+
       - name: Push changes
+        if: env.DRY_RUN == 'false' && steps.check_update.outputs.changed == '1'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
           tags: true
-        if: env.DRY_RUN == 'false'
+
       - name: Push changes (dry_run)
+        if: env.DRY_RUN == 'true' && steps.check_update.outputs.changed == '1'
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}
           tags: false
-        if: env.DRY_RUN == 'true'
 
   build-dotnet:
     needs: [update-packagejson]

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,35 +1,95 @@
 name: Build-Release
 
 on:
-  push:
-    tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "tag: git tag you want create. (sample 1.0.0)"
+        required: true
+      dry_run:
+        description: "dry_run: true will never create relase/nuget."
+        required: true
+        default: "false"
+
+env:
+  GIT_TAG: ${{ github.event.inputs.tag }}
+  DRY_RUN: ${{ github.event.inputs.dry_run }}
+  DRY_RUN_BRANCH_PREFIX: "test_release"
+  DOTNET_SDK_VERISON_3: 3.1.x
 
 jobs:
-  build-dotnet:
+  update-packagejson:
     runs-on: ubuntu-latest
+    env:
+      TARGET_FILE: ./src/ZString.Unity/Assets/Scripts/ZString/package.json
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: before
+        run: cat ${{ env.TARGET_FILE}}
+      - name: update package.json to version ${{ env.GIT_TAG }}
+        run: sed -i -e "s/\(\"version\":\) \"\(.*\)\",/\1 \"${{ env.GIT_TAG }}\",/" ${{ env.TARGET_FILE }}
+      - name: after
+        run: cat ${{ env.TARGET_FILE}}
+      - name: Commit files
+        id: commit
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git commit -m "feat: Update package.json to ${{ env.GIT_TAG }}" -a
+          echo "::set-output name=sha::$(git rev-parse HEAD)"
+      - name: check sha
+        run: echo "SHA ${SHA}"
+        env:
+          SHA: ${{ steps.commit.outputs.sha }}
+      - name: tag
+        run: git tag ${{ env.GIT_TAG }}
+        if: env.DRY_RUN == 'false'
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}
+          tags: true
+        if: env.DRY_RUN == 'false'
+      - name: Push changes (dry_run)
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}
+          tags: false
+        if: env.DRY_RUN == 'true'
+
+  build-dotnet:
+    needs: [update-packagejson]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
     steps:
+      - run: echo ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.update-packagejson.outputs.sha }}
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: "${{ env.DOTNET_SDK_VERSION_3 }}"
       # set release tag(*.*.*) to env.GIT_TAG
       - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - run: dotnet build src/ZString -c Release -p:Version=${{ env.GIT_TAG }}
       - run: dotnet test tests/ZString.Tests -c Release --no-build
-      - run: dotnet pack ./src/ZString/ZString.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }}
-
+      - run: dotnet pack ./src/ZString/ZString.csproj -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
       # Store artifacts.
       - uses: actions/upload-artifact@v1
         with:
           name: nuget
-          path: ./src/ZString/bin/Release/ZString.${{ env.GIT_TAG }}.nupkg
+          path: ./publish/
 
   build-unity:
+    needs: [update-packagejson]
     strategy:
       matrix:
         unity: ["2019.3.9f1"]
@@ -37,12 +97,19 @@ jobs:
           - unity: 2019.3.9f1
             license: UNITY_2019_3
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container:
       # with linux-il2cpp. image from https://hub.docker.com/r/gableroux/unity3d/tags
       image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      - run: apt update && apt install git -y
+      # Ubuntu 18.04 git is too old, use ppa latest git.
+      - run: |
+          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
+          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ needs.update-packagejson.outputs.sha }}
+      # activate Unity from manual license file(ulf)
       - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
@@ -58,6 +125,16 @@ jobs:
         env:
           UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
 
+      - name: check all .meta is commited
+        run: |
+          if git ls-files --others --exclude-standard -t | grep --regexp='[.]meta$'; then
+            echo "Detected .meta file generated. Do you forgot commit a .meta file?"
+            exit 1
+          else
+            echo "Great, all .meta files are commited."
+          fi
+        working-directory: src/ZString.Unity
+
       # Store artifacts.
       - uses: actions/upload-artifact@v1
         with:
@@ -65,35 +142,32 @@ jobs:
           path: ./src/ZString.Unity/ZString.Unity.${{ env.GIT_TAG }}.unitypackage
 
   create-release:
-    needs: [build-dotnet, build-unity]
+    if: github.event.inputs.dry_run == 'false'
+    needs: [update-packagejson, build-dotnet, build-unity]
     runs-on: ubuntu-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       NUGET_XMLDOC_MODE: skip
     steps:
-      # setup dotnet for nuget push
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      # Create Releases
+          dotnet-version: "${{ env.DOTNET_SDK_VERSION_3 }}"
+      # Create Release
       - uses: actions/create-release@v1
         id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Ver.${{ github.ref }}
-
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: Ver.${{ env.GIT_TAG }}
+          commitish: ${{ needs.update-packagejson.outputs.sha }}
+          draft: true
+          prerelease: false
       # Download (All) Artifacts to current directory
       - uses: actions/download-artifact@v2-preview
-
       # Upload to NuGet
-      - run: dotnet nuget push "./nuget/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
-
+      - run: dotnet nuget push "./nuget/*.nupkg" --skip-duplicate -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
       # Upload to Releases(unitypackage)
       - uses: actions/upload-release-asset@v1
         env:
@@ -103,3 +177,14 @@ jobs:
           asset_path: ./ZString.Unity.${{ env.GIT_TAG }}.unitypackage/ZString.Unity.${{ env.GIT_TAG }}.unitypackage
           asset_name: ZString.Unity.${{ env.GIT_TAG }}.unitypackage
           asset_content_type: application/octet-stream
+
+  cleanup:
+    if: github.event.inputs.dry_run == 'true'
+    needs: [build-dotnet, build-unity]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete branch
+        uses: dawidd6/action-delete-branch@v3
+        with:
+          github_token: ${{ github.token }}
+          branches: ${{ env.DRY_RUN_BRANCH_PREFIX }}-${{ env.GIT_TAG }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,35 +95,26 @@ jobs:
         unity: ["2019.3.9f1"]
         include:
           - unity: 2019.3.9f1
-            license: UNITY_2019_3
+            license: UNITY_LICENSE_2019
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    container:
-      # with linux-il2cpp. image from https://hub.docker.com/r/gableroux/unity3d/tags
-      image: gableroux/unity3d:${{ matrix.unity }}-linux-il2cpp
     steps:
-      # Ubuntu 18.04 git is too old, use ppa latest git.
-      - run: |
-          apt-get update && apt-get install --no-install-recommends -y software-properties-common && add-apt-repository -y ppa:git-core/ppa
-          apt-get update && apt-get install --no-install-recommends -y git
       - uses: actions/checkout@v2
         with:
           ref: ${{ needs.update-packagejson.outputs.sha }}
-      # activate Unity from manual license file(ulf)
-      - run: echo -n "$UNITY_LICENSE" >> .Unity.ulf
+      # Execute scripts: Export Package
+      # /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
+      - name: Export unitypackage
+        uses: game-ci/unity-builder@v2.0-alpha-6
         env:
           UNITY_LICENSE: ${{ secrets[matrix.license] }}
-      - run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -manualLicenseFile .Unity.ulf || exit 0
-
-      # set release tag(*.*.*) to env.GIT_TAG
-      - run: echo "GIT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-
-      # Execute scripts: Export Package
-      - name: Export unitypackage
-        run: /opt/Unity/Editor/Unity -quit -batchmode -nographics -silent-crashes -logFile -projectPath . -executeMethod PackageExporter.Export
-        working-directory: src/ZString.Unity
-        env:
           UNITY_PACKAGE_VERSION: ${{ env.GIT_TAG }}
+        with:
+          projectPath: src/ZString.Unity
+          unityVersion: ${{ matrix.unity }}
+          targetPlatform: StandaloneLinux64
+          buildMethod: PackageExporter.Export
+          versioning: None
 
       - name: check all .meta is commited
         run: |


### PR DESCRIPTION
Please merge after #41 is merged.

## TL;DR

* change: ci image update to unityci/editor.
* change: unity ci to build with actions.

## Summary

* gableroux/unity3d is deprecated and moved to unityci/editor.
* Unity License Activation / Build is handle with actions `game-ci/unity-builder`, no more direct batch mode call.

## Effect

* ALF/ULF License is not compatible with gableroux/unity3d, new ULF is used in unityci/editor.
