### PR TITLE
Make StringBuilder follow the protocol of IDisposable.

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -97,18 +97,18 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
-            if (buffer.Length != ThreadStaticBufferSize)
+            if (buffer != null)
             {
-                if (buffer != null)
+                if (buffer.Length != ThreadStaticBufferSize)
                 {
                     ArrayPool<char>.Shared.Return(buffer);
                 }
-            }
-            buffer = null;
-            index = 0;
-            if (disposeImmediately)
-            {
-                scratchBufferUsed = false;
+                buffer = null;
+                index = 0;
+                if (disposeImmediately)
+                {
+                    scratchBufferUsed = false;
+                }
             }
         }
 

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
@@ -103,18 +103,18 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
-            if (buffer.Length != ThreadStaticBufferSize)
+            if (buffer != null)
             {
-                if (buffer != null)
+                if (buffer.Length != ThreadStaticBufferSize)
                 {
                     ArrayPool<byte>.Shared.Return(buffer);
                 }
-            }
-            buffer = null;
-            index = 0;
-            if (disposeImmediately)
-            {
-                scratchBufferUsed = false;
+                buffer = null;
+                index = 0;
+                if (disposeImmediately)
+                {
+                    scratchBufferUsed = false;
+                }
             }
         }
 

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -97,18 +97,18 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
-            if (buffer.Length != ThreadStaticBufferSize)
+            if (buffer != null)
             {
-                if (buffer != null)
+                if (buffer.Length != ThreadStaticBufferSize)
                 {
                     ArrayPool<char>.Shared.Return(buffer);
                 }
-            }
-            buffer = null;
-            index = 0;
-            if (disposeImmediately)
-            {
-                scratchBufferUsed = false;
+                buffer = null;
+                index = 0;
+                if (disposeImmediately)
+                {
+                    scratchBufferUsed = false;
+                }
             }
         }
 

--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -103,18 +103,18 @@ namespace Cysharp.Text
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Dispose()
         {
-            if (buffer.Length != ThreadStaticBufferSize)
+            if (buffer != null)
             {
-                if (buffer != null)
+                if (buffer.Length != ThreadStaticBufferSize)
                 {
                     ArrayPool<byte>.Shared.Return(buffer);
                 }
-            }
-            buffer = null;
-            index = 0;
-            if (disposeImmediately)
-            {
-                scratchBufferUsed = false;
+                buffer = null;
+                index = 0;
+                if (disposeImmediately)
+                {
+                    scratchBufferUsed = false;
+                }
             }
         }
 

--- a/tests/ZString.Tests/StringBuilderTest.cs
+++ b/tests/ZString.Tests/StringBuilderTest.cs
@@ -1,0 +1,26 @@
+using Cysharp.Text;
+using FluentAssertions;
+using System.Text;
+using Xunit;
+
+namespace ZStringTests
+{
+    public class StringBuilderTest
+    {
+        [Fact]
+        public void Utf16DisposeTest()
+        {
+            var sb = ZString.CreateStringBuilder();
+            sb.Dispose();
+            sb.Dispose(); // call more than once
+        }
+
+        [Fact]
+        public void Utf8DisposeTest()
+        {
+            var sb = ZString.CreateUtf8StringBuilder();
+            sb.Dispose();
+            sb.Dispose(); // call more than once
+        }
+    }
+}


### PR DESCRIPTION
[IDisposable](https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose)  requires the following.

> If an object's Dispose method is called more than once, the object must ignore all calls after the first one. The object must not throw an exception if its Dispose method is called multiple times. 

`Utf16ValueStringBuilder` and `Utf8ValueStringBuilder` are now throwing exceptions and have been fixed.