### PR TITLE
Mantained TextMeshProExtensions.cs

### DIFF
--- a/src/ZString/Unity/TextMeshProExtensions.cs
+++ b/src/ZString/Unity/TextMeshProExtensions.cs
@@ -5,6 +5,16 @@ namespace Cysharp.Text
 {
     public static partial class TextMeshProExtensions
     {
+        public static void SetText<T>(this TMP_Text text, T arg0)
+        {
+            using ( var sb = new Cysharp.Text.Utf16ValueStringBuilder( true ) )
+            {
+                sb.Append(arg0);
+                var array = sb.AsArraySegment();
+                text.SetCharArray(array.Array, array.Offset, array.Count);
+            }
+        }
+        
         public static void SetTextFormat<T0>(this TMP_Text text, string format, T0 arg0)
         {
             using (var sb = new Cysharp.Text.Utf16ValueStringBuilder(true))

--- a/src/ZString/Unity/TextMeshProExtensions.tt
+++ b/src/ZString/Unity/TextMeshProExtensions.tt
@@ -26,8 +26,18 @@ using TMPro;
 
 namespace Cysharp.Text
 {
-    public static class TextMeshProExtensions
+    public static partial class TextMeshProExtensions
     {
+        public static void SetText<T>(this TMP_Text text, T arg0)
+        {
+            using ( var sb = new Cysharp.Text.Utf16ValueStringBuilder( true ) )
+            {
+                sb.Append(arg0);
+                var array = sb.AsArraySegment();
+                text.SetCharArray(array.Array, array.Offset, array.Count);
+            }
+        }
+        
 <# for(var i = 1; i <= 16; i++) { #>
         public static void SetTextFormat<<#= CreateTypeArgument(i) #>>(this TMP_Text text, string format, <#= CreateParameters(i) #>)
         {


### PR DESCRIPTION
After #33, TextMeshProExtensions.cs reverts to the previous revision when building.

I copied it from `src/ZString.Unity/Assets/Scripts/ZString/Unity/TextMeshProExtensions.cs` to `src/ZString/Unity/TextMeshProExtensions.cs`.