### PR TITLE
Add ReplaceAt method to Utf16ValueStringBuilder

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -469,6 +469,22 @@ namespace Cysharp.Text
             buffer = newBuffer;
             index = newBufferIndex;
         }
+        
+        /// <summary>
+        /// Replaces the contents of a single position within the builder.
+        /// </summary>
+        /// <param name="newChar">The character to use at the position.</param>
+        /// <param name="replaceIndex">The index to replace.</param>
+        public void ReplaceAt(char newChar, int replaceIndex)
+        {
+            int currentLength = Length;
+            if ((uint)replaceIndex > (uint)currentLength)
+            {
+                ExceptionUtil.ThrowArgumentOutOfRangeException(nameof(replaceIndex));
+            }
+            
+            buffer[replaceIndex] = newChar;
+        }
 
         /// <summary>
         /// Removes a range of characters from this builder.

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -469,6 +469,22 @@ namespace Cysharp.Text
             buffer = newBuffer;
             index = newBufferIndex;
         }
+        
+        /// <summary>
+        /// Replaces the contents of a single position within the builder.
+        /// </summary>
+        /// <param name="newChar">The character to use at the position.</param>
+        /// <param name="replaceIndex">The index to replace.</param>
+        public void ReplaceAt(char newChar, int replaceIndex)
+        {
+            int currentLength = Length;
+            if ((uint)replaceIndex > (uint)currentLength)
+            {
+                ExceptionUtil.ThrowArgumentOutOfRangeException(nameof(replaceIndex));
+            }
+            
+            buffer[replaceIndex] = newChar;
+        }
 
         /// <summary>
         /// Removes a range of characters from this builder.

--- a/tests/ZString.Tests/ReplaceTest.cs
+++ b/tests/ZString.Tests/ReplaceTest.cs
@@ -7,6 +7,19 @@ namespace ZStringTests
 {
     public class ReplaceTest
     {
+        
+        [Fact]
+        public void ReplaceAtCharTest()
+        {
+            var s = new string(' ', 10);
+            using (var zsb = ZString.CreateStringBuilder())
+            {
+                zsb.Append(s);
+                zsb.ReplaceAt('-',2);
+                zsb.ToString().Should().Be(new StringBuilder(s) { [2] = '-'}.ToString());
+            }
+        }
+        
         [Fact]
         public void ReplaceCharTest()
         {


### PR DESCRIPTION
This PR adds a `.ReplaceAt(char,int)` method to `Utf16ValueStringBuilder`.

Purpose of this method is to provide a way to efficiently replace a single character in the stringbuilder, without having to use the `Replace()` overloads that require extra bounds checks/loops/copies.