### PR TITLE
Imporved performance of Utf16ValueStringBuilder.AppendFormat on Slow Span Environment

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -27,7 +27,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -35,7 +35,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -57,7 +57,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -74,7 +74,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -101,7 +101,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -109,7 +109,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -134,7 +134,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -151,7 +151,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -178,7 +178,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -186,7 +186,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -214,7 +214,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -231,7 +231,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -258,7 +258,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -266,7 +266,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -297,7 +297,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -314,7 +314,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -341,7 +341,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -349,7 +349,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -383,7 +383,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -400,7 +400,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -427,7 +427,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -435,7 +435,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -472,7 +472,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -489,7 +489,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -516,7 +516,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -524,7 +524,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -564,7 +564,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -581,7 +581,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -608,7 +608,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -616,7 +616,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -659,7 +659,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -676,7 +676,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -703,7 +703,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -711,7 +711,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -757,7 +757,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -774,7 +774,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -801,7 +801,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -809,7 +809,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -858,7 +858,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -875,7 +875,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -902,7 +902,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -910,7 +910,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -962,7 +962,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -979,7 +979,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1006,7 +1006,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1014,7 +1014,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1069,7 +1069,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1086,7 +1086,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1113,7 +1113,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1121,7 +1121,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1179,7 +1179,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1196,7 +1196,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1223,7 +1223,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1231,7 +1231,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1292,7 +1292,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1309,7 +1309,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1336,7 +1336,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1344,7 +1344,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1408,7 +1408,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1425,7 +1425,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1452,7 +1452,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1460,7 +1460,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1527,7 +1527,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1544,7 +1544,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -220,6 +220,44 @@ namespace Cysharp.Text
             AppendLine();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string value, int startIndex, int count)
+        {
+            if (value == null)
+            {
+                if (startIndex == 0 && count == 0)
+                {
+                    return;
+                }
+                else
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+            }
+
+#if UNITY_2018_3_OR_NEWER
+            if (buffer.Length - index < count)
+            {
+                Grow(count);
+            }
+            value.CopyTo(startIndex, buffer, index, count);
+            index += count;
+#else
+            Append(value.AsSpan(startIndex, count));
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char[] value, int startIndex, int charCount)
+        {
+            if (buffer.Length - index < charCount)
+            {
+                Grow(charCount);
+            }
+            Array.Copy(value, startIndex, buffer, index, charCount);
+            index += charCount;
+        }
+
         /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(ReadOnlySpan<char> value)

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZStringWriter.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZStringWriter.cs
@@ -79,7 +79,7 @@ namespace Cysharp.Text
             }
             AssertNotDisposed();
 
-            sb.Append(buffer.AsSpan(index, count));
+            sb.Append(buffer, index, count);
         }
 
         public override void Write(string value)

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -27,7 +27,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -35,7 +35,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -57,7 +57,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -74,7 +74,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -101,7 +101,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -109,7 +109,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -134,7 +134,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -151,7 +151,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -178,7 +178,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -186,7 +186,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -214,7 +214,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -231,7 +231,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -258,7 +258,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -266,7 +266,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -297,7 +297,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -314,7 +314,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -341,7 +341,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -349,7 +349,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -383,7 +383,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -400,7 +400,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -427,7 +427,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -435,7 +435,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -472,7 +472,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -489,7 +489,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -516,7 +516,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -524,7 +524,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -564,7 +564,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -581,7 +581,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -608,7 +608,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -616,7 +616,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -659,7 +659,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -676,7 +676,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -703,7 +703,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -711,7 +711,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -757,7 +757,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -774,7 +774,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -801,7 +801,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -809,7 +809,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -858,7 +858,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -875,7 +875,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -902,7 +902,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -910,7 +910,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -962,7 +962,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -979,7 +979,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1006,7 +1006,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1014,7 +1014,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1069,7 +1069,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1086,7 +1086,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1113,7 +1113,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1121,7 +1121,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1179,7 +1179,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1196,7 +1196,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1223,7 +1223,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1231,7 +1231,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1292,7 +1292,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1309,7 +1309,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1336,7 +1336,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1344,7 +1344,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1408,7 +1408,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1425,7 +1425,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1452,7 +1452,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1460,7 +1460,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -1527,7 +1527,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1544,7 +1544,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
@@ -35,7 +35,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -43,7 +43,7 @@ namespace Cysharp.Text
                     else
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                     }
 
                     // try to find range
@@ -67,7 +67,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -84,7 +84,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -220,6 +220,44 @@ namespace Cysharp.Text
             AppendLine();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string value, int startIndex, int count)
+        {
+            if (value == null)
+            {
+                if (startIndex == 0 && count == 0)
+                {
+                    return;
+                }
+                else
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+            }
+
+#if UNITY_2018_3_OR_NEWER
+            if (buffer.Length - index < count)
+            {
+                Grow(count);
+            }
+            value.CopyTo(startIndex, buffer, index, count);
+            index += count;
+#else
+            Append(value.AsSpan(startIndex, count));
+#endif
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char[] value, int startIndex, int charCount)
+        {
+            if (buffer.Length - index < charCount)
+            {
+                Grow(charCount);
+            }
+            Array.Copy(value, startIndex, buffer, index, charCount);
+            index += charCount;
+        }
+
         /// <summary>Appends a contiguous region of arbitrary memory to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(ReadOnlySpan<char> value)

--- a/src/ZString/ZStringWriter.cs
+++ b/src/ZString/ZStringWriter.cs
@@ -79,7 +79,7 @@ namespace Cysharp.Text
             }
             AssertNotDisposed();
 
-            sb.Append(buffer.AsSpan(index, count));
+            sb.Append(buffer, index, count);
         }
 
         public override void Write(string value)


### PR DESCRIPTION
For environments like Mono and .NET Framework, I reduced the Span used in Utaf16ValueStringBuilder.AppendFormat.

# Benchmark on .NET Framework

```
$ dotnet run -c Release --framework net47
Available Benchmarks:
  #0 AppendPerformance
  #1 FormatBenchmark
...
1
```

```
BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19043
AMD Ryzen 5 5600X, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=6.0.100-preview.4.21255.9
  [Host]   : .NET Core 5.0.6 (CoreCLR 5.0.621.22011, CoreFX 5.0.621.22011), X64 RyuJIT  [AttachedDebugger]
  ShortRun : .NET Framework 4.8 (4.8.4341.0), X64 RyuJIT

Job=ShortRun  Runtime=.NET 4.7  IterationCount=1
LaunchCount=1  WarmupCount=1
```

## Before
|                Method |      Mean | Error | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |----------:|------:|------:|-------:|------:|------:|----------:|
|          StringFormat | 155.02 ns |    NA |  1.00 | 0.1013 |     - |     - |     169 B |
|         ZStringFormat | 149.62 ns |    NA |  0.97 | 0.0336 |     - |     - |      56 B |
| ZStringPreparedFormat | 122.82 ns |    NA |  0.79 | 0.0336 |     - |     - |      56 B |
| StringFormatterFormat |  81.76 ns |    NA |  0.53 | 0.0337 |     - |     - |      56 B |
## After

|                Method |      Mean | Error | Ratio |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |----------:|------:|------:|-------:|------:|------:|----------:|
|          StringFormat | 153.41 ns |    NA |  1.00 | 0.1013 |     - |     - |     169 B |
|         ZStringFormat | 133.61 ns |    NA |  0.87 | 0.0336 |     - |     - |      56 B |
| ZStringPreparedFormat | 122.32 ns |    NA |  0.80 | 0.0336 |     - |     - |      56 B |
| StringFormatterFormat |  81.04 ns |    NA |  0.53 | 0.0337 |     - |     - |      56 B |
