### PR TITLE
remove uint casts

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16ValueStringBuilder.cs
@@ -228,7 +228,7 @@ namespace Cysharp.Text
             {
                 Grow(value.Length);
             }
-            
+
             value.CopyTo(buffer.AsSpan(index));
             index += value.Length;
         }
@@ -347,7 +347,7 @@ namespace Cysharp.Text
         public void Replace(char oldChar, char newChar, int startIndex, int count)
         {
             int currentLength = Length;
-            if ((uint)startIndex > (uint)currentLength)
+            if (startIndex > currentLength)
             {
                 ExceptionUtil.ThrowArgumentOutOfRangeException(nameof(startIndex));
             }

--- a/src/ZString/Utf16ValueStringBuilder.cs
+++ b/src/ZString/Utf16ValueStringBuilder.cs
@@ -228,7 +228,7 @@ namespace Cysharp.Text
             {
                 Grow(value.Length);
             }
-            
+
             value.CopyTo(buffer.AsSpan(index));
             index += value.Length;
         }
@@ -293,7 +293,7 @@ namespace Cysharp.Text
             }
 
             int currentLength = Length;
-            if ((uint)index > (uint)currentLength)
+            if (index > currentLength)
             {
                 ExceptionUtil.ThrowArgumentOutOfRangeException(nameof(index));
             }
@@ -347,7 +347,7 @@ namespace Cysharp.Text
         public void Replace(char oldChar, char newChar, int startIndex, int count)
         {
             int currentLength = Length;
-            if ((uint)startIndex > (uint)currentLength)
+            if (startIndex > currentLength)
             {
                 ExceptionUtil.ThrowArgumentOutOfRangeException(nameof(startIndex));
             }
@@ -406,7 +406,7 @@ namespace Cysharp.Text
         {
             int currentLength = Length;
 
-            if ((uint)startIndex > (uint)currentLength)
+            if (startIndex > currentLength)
             {
                 ExceptionUtil.ThrowArgumentOutOfRangeException(nameof(startIndex));
             }


### PR DESCRIPTION
why would int be cast to uint for comparison?