### PR TITLE
Add ReadOnlySpan<char>based format AppendFormat for Utf16ValueStringBuilder

### DIFF
--- a/sandbox/PerfBenchmark/Benchmarks/StringBuilderAppendFormat.cs
+++ b/sandbox/PerfBenchmark/Benchmarks/StringBuilderAppendFormat.cs
@@ -1,0 +1,68 @@
+﻿using BenchmarkDotNet.Attributes;
+using Cysharp.Text;
+using System;
+using System.Text;
+
+namespace PerfBenchmark.Benchmarks
+{
+    [Config(typeof(BenchmarkConfig))]
+    public class StringBuilderAppendFormat
+    {
+        double[] dValues;
+        float[] fValues;
+        decimal[] mValues;
+        public StringBuilderAppendFormat()
+        {
+            dValues = new[] { 0d, double.MaxValue, double.MinValue };
+            fValues = new[] { 0f, float.MaxValue, float.MinValue };
+            mValues = new[] { 0m, decimal.MaxValue, decimal.MinValue };
+
+#if NETCOREAPP || NETSTANDARD2_1
+            if (StringBuilder() != ZStringBuilder())
+                throw new Exception();
+#endif
+        }
+
+
+#if NETCOREAPP || NETSTANDARD2_1
+        [Benchmark(Baseline = true)]
+        public int StringBuilder()
+        {
+            var sb = new StringBuilder();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "double", dValues[0], dValues[1], dValues[2]);
+            sb.AppendLine();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "float", fValues[0], fValues[1], fValues[2]);
+            sb.AppendLine();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "decimal", mValues[0], mValues[1], mValues[2]);
+            sb.AppendLine();
+            return sb.Length;
+        }
+#endif
+
+        [Benchmark]
+        public int ZStringBuilder()
+        {
+            using var sb = ZString.CreateStringBuilder();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "double", dValues[0], dValues[1], dValues[2]);
+            sb.AppendLine();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "float", fValues[0], fValues[1], fValues[2]);
+            sb.AppendLine();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "decimal", mValues[0], mValues[1], mValues[2]);
+            sb.AppendLine();
+            return sb.Length;
+        }
+
+        [Benchmark]
+        public int ZStringBuilderUtf8()
+        {
+            using var sb = ZString.CreateUtf8StringBuilder();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "double", dValues[0], dValues[1], dValues[2]);
+            sb.AppendLine();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "float", fValues[0], fValues[1], fValues[2]);
+            sb.AppendLine();
+            sb.AppendFormat("{0}: {1}, {2}, {3}", "decimal", mValues[0], mValues[1], mValues[2]);
+            sb.AppendLine();
+            return sb.Length;
+        }
+    }
+}

--- a/sandbox/PerfBenchmark/Benchmarks/StringBuilderAppendFormat.cs
+++ b/sandbox/PerfBenchmark/Benchmarks/StringBuilderAppendFormat.cs
@@ -29,11 +29,11 @@ namespace PerfBenchmark.Benchmarks
         public int StringBuilder()
         {
             var sb = new StringBuilder();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "double", dValues[0], dValues[1], dValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "double", dValues[0], dValues[1], dValues[2], 1);
             sb.AppendLine();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "float", fValues[0], fValues[1], fValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "float", fValues[0], fValues[1], fValues[2], 2);
             sb.AppendLine();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "decimal", mValues[0], mValues[1], mValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "decimal", mValues[0], mValues[1], mValues[2], 3);
             sb.AppendLine();
             return sb.Length;
         }
@@ -43,11 +43,11 @@ namespace PerfBenchmark.Benchmarks
         public int ZStringBuilder()
         {
             using var sb = ZString.CreateStringBuilder();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "double", dValues[0], dValues[1], dValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "double", dValues[0], dValues[1], dValues[2], 1);
             sb.AppendLine();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "float", fValues[0], fValues[1], fValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "float", fValues[0], fValues[1], fValues[2], 2);
             sb.AppendLine();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "decimal", mValues[0], mValues[1], mValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "decimal", mValues[0], mValues[1], mValues[2], 3);
             sb.AppendLine();
             return sb.Length;
         }
@@ -56,11 +56,11 @@ namespace PerfBenchmark.Benchmarks
         public int ZStringBuilderUtf8()
         {
             using var sb = ZString.CreateUtf8StringBuilder();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "double", dValues[0], dValues[1], dValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "double", dValues[0], dValues[1], dValues[2], 1);
             sb.AppendLine();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "float", fValues[0], fValues[1], fValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "float", fValues[0], fValues[1], fValues[2], 2);
             sb.AppendLine();
-            sb.AppendFormat("{0}: {1}, {2}, {3}", "decimal", mValues[0], mValues[1], mValues[2]);
+            sb.AppendFormat("{{ {0}: {1}, {2}, {3} }} - {4}", "decimal", mValues[0], mValues[1], mValues[2], 3);
             sb.AppendLine();
             return sb.Length;
         }

--- a/src/ZString.Unity/Assets/Scripts/ZString/FormatParser.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/FormatParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
@@ -26,6 +26,47 @@ namespace Cysharp.Text
         internal const int ArgLengthLimit = 16;
         internal const int WidthLimit = 1000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParserScanResult ScanFormatString(string format, ref int i)
+        {
+            var len = format.Length;
+            char c = format[i];
+
+            i++; // points netxt char
+            if (c == '}')
+            {
+                // skip escaped '}'
+                if (i < len && format[i] == '}')
+                {
+                    i++;
+                    return ParserScanResult.EscapedChar;
+                }
+                else
+                {
+                    ExceptionUtil.ThrowFormatError();
+                    return ParserScanResult.NormalChar; // NOTE Don't reached
+                }
+            }
+            else if (c == '{')
+            {
+                // skip escaped '{'
+                if (i < len && format[i] == '{')
+                {
+                    i++;
+                    return ParserScanResult.EscapedChar;
+                }
+                else
+                {
+                    i--;
+                    return ParserScanResult.BraceOpen;
+                }
+            }
+            else
+            {
+                // ch is the normal char OR end of text
+                return ParserScanResult.NormalChar;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ParserScanResult ScanFormatString(ReadOnlySpan<char> format, ref int i)
@@ -72,6 +113,141 @@ namespace Cysharp.Text
         // Accept only non-unicode numbers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsDigit(char c) => '0' <= c && c <= '9';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParseResult Parse(ReadOnlySpan<char> format, int i)
+        {
+            char c = default;
+            var len = format.Length;
+
+            i++; // Skip `{`
+
+            //  === Index Component ===
+            //   ('0'-'9')+ WS*
+
+            if (i == len || !IsDigit(c = format[i]))
+            {
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            int paramIndex = 0;
+            do
+            {
+                paramIndex = (paramIndex * 10) + c - '0';
+
+                if (++i == len)
+                    ExceptionUtil.ThrowFormatError();
+
+                c = format[i];
+            }
+            while (IsDigit(c) && paramIndex < ArgLengthLimit);
+
+            if (paramIndex >= ArgLengthLimit)
+            {
+                ExceptionUtil.ThrowFormatException();
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Alignment Component ===
+            //   comma WS* minus? ('0'-'9')+ WS*
+
+            int alignment = 0;
+
+            if (c == ',')
+            {
+                i++;
+
+                // skip whitespace.
+                while (i < len && (c = format[i]) == ' ')
+                    i++;
+
+                if (i == len)
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                var leftJustify = false;
+                if (c == '-')
+                {
+                    leftJustify = true;
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+
+                if (!IsDigit(c))
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                do
+                {
+                    alignment = (alignment * 10) + c - '0';
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+                while (IsDigit(c) && alignment < WidthLimit);
+
+                if (leftJustify)
+                    alignment *= -1;
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Format String Component ===
+
+            ReadOnlySpan<char> itemFormatSpan = default;
+
+            if (c == ':')
+            {
+                i++;
+                int formatStart = i;
+
+                while (true)
+                {
+                    if (i == len)
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+                    c = format[i];
+
+                    if (c == '}')
+                    {
+                        break;
+                    }
+                    else if (c == '{')
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+
+                    i++;
+                }
+
+                // has format
+                if (i > formatStart)
+                {
+                    itemFormatSpan = format.Slice(formatStart, i - formatStart);
+                }
+            }
+            else if (c != '}')
+            {
+                // Unexpected character
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            i++; // Skip `}`
+            return new ParseResult(paramIndex, itemFormatSpan, i, alignment);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ParseResult Parse(string format, int i)
@@ -208,6 +384,7 @@ namespace Cysharp.Text
             return new ParseResult(paramIndex, itemFormatSpan, i, alignment);
         }
     }
+
     internal enum ParserScanResult
     {
         BraceOpen,

--- a/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormatHelper.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/PreparedFormatHelper.cs
@@ -20,13 +20,12 @@ namespace Cysharp.Text
             int len = format.Length;
 
             var copyFrom = 0;
-            var formatSpan = format.AsSpan();
 
             while (true)
             {
                 while (i < len)
                 {
-                    var parserScanResult = FormatParser.ScanFormatString(formatSpan, ref i);
+                    var parserScanResult = FormatParser.ScanFormatString(format, ref i);
 
                     if (ParserScanResult.NormalChar == parserScanResult && i < len)
                     {
@@ -84,13 +83,12 @@ namespace Cysharp.Text
             int len = format.Length;
 
             var copyFrom = 0;
-            var formatSpan = format.AsSpan();
 
             while (true)
             {
                 while (i < len)
                 {
-                    var parserScanResult = FormatParser.ScanFormatString(formatSpan, ref i);
+                    var parserScanResult = FormatParser.ScanFormatString(format, ref i);
 
                     if (ParserScanResult.NormalChar == parserScanResult && i < len)
                     {

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Cysharp.Text
 {
@@ -79,6 +79,75 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1>(ReadOnlySpan<char> format, T1 arg1)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2>(string format, T1 arg1, T2 arg2)
         {
             if (format == null)
@@ -152,6 +221,78 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2>(ReadOnlySpan<char> format, T1 arg1, T2 arg2)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -236,6 +377,81 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             if (format == null)
@@ -315,6 +531,84 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -405,6 +699,87 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             if (format == null)
@@ -490,6 +865,90 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -586,6 +1045,93 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             if (format == null)
@@ -677,6 +1223,96 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -779,6 +1415,99 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             if (format == null)
@@ -876,6 +1605,102 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -984,6 +1809,105 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             if (format == null)
@@ -1087,6 +2011,108 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -1201,6 +2227,111 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             if (format == null)
@@ -1310,6 +2441,114 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        case 13:
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -1430,6 +2669,117 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        case 13:
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
+                            continue;
+                        case 14:
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
             if (format == null)
@@ -1545,6 +2895,120 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        case 13:
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
+                            continue;
+                        case 14:
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
+                            continue;
+                        case 15:
+                            AppendFormatInternal(arg16, indexParse.Alignment, indexParse.FormatString, nameof(arg16));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
@@ -28,7 +28,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -59,7 +59,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -77,7 +77,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -105,7 +105,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -139,7 +139,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -157,7 +157,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -185,7 +185,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -222,7 +222,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -240,7 +240,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -268,7 +268,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -308,7 +308,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -326,7 +326,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -354,7 +354,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -397,7 +397,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -415,7 +415,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -443,7 +443,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -489,7 +489,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -507,7 +507,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -535,7 +535,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -584,7 +584,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -602,7 +602,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -630,7 +630,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -682,7 +682,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -700,7 +700,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -728,7 +728,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -783,7 +783,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -801,7 +801,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -829,7 +829,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -887,7 +887,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -905,7 +905,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -933,7 +933,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -994,7 +994,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1012,7 +1012,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1040,7 +1040,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1104,7 +1104,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1122,7 +1122,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1150,7 +1150,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1217,7 +1217,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1235,7 +1235,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1263,7 +1263,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1333,7 +1333,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1351,7 +1351,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1379,7 +1379,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1452,7 +1452,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1470,7 +1470,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1498,7 +1498,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1574,7 +1574,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1592,7 +1592,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }

--- a/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Utf8ValueStringBuilder.cs
@@ -224,11 +224,38 @@ namespace Cysharp.Text
             AppendLine();
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string value, int startIndex, int count)
+        {
+            if (value == null)
+            {
+                if (startIndex == 0 && count == 0)
+                {
+                    return;
+                }
+                else
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+            }
+
+#if UNITY_2018_3_OR_NEWER || NETSTANDARD2_0
+            var maxLen = UTF8NoBom.GetMaxByteCount(count);
+            if (buffer.Length - index < maxLen)
+            {
+                Grow(count);
+            }
+            index += UTF8NoBom.GetBytes(value, startIndex, count, buffer, index);
+#else
+            Append(value.AsSpan(startIndex, count));
+#endif
+        }
+
         /// <summary>Appends the string representation of a specified value to this instance.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Append(string value)
         {
-#if UNITY_2018_3_OR_NEWER || NETSTANDARD2_0
+#if !UNITY_2020_2_OR_NEWER && (UNITY_2018_3_OR_NEWER || NETSTANDARD2_0)
             var maxLen = UTF8NoBom.GetMaxByteCount(value.Length);
             if (buffer.Length - index < maxLen)
             {

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.Format.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.Format.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System;
 
 namespace Cysharp.Text
 {
@@ -22,6 +23,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1>(ReadOnlySpan<char> format, T1 arg1)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2>(string format, T1 arg1, T2 arg2)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -36,6 +52,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2>(ReadOnlySpan<char> format, T1 arg1, T2 arg2)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3)
@@ -54,6 +85,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -68,6 +114,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
@@ -86,6 +147,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -100,6 +176,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
@@ -118,6 +209,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -132,6 +238,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
@@ -150,6 +271,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -164,6 +300,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
@@ -182,6 +333,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -196,6 +362,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
@@ -214,6 +395,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -228,6 +424,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
@@ -246,6 +457,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -260,5 +486,20 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
     }
 }

--- a/src/ZString/FormatParser.cs
+++ b/src/ZString/FormatParser.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace Cysharp.Text
@@ -26,6 +26,47 @@ namespace Cysharp.Text
         internal const int ArgLengthLimit = 16;
         internal const int WidthLimit = 1000; // Note:  -WidthLimit <  ArgAlign < WidthLimit
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParserScanResult ScanFormatString(string format, ref int i)
+        {
+            var len = format.Length;
+            char c = format[i];
+
+            i++; // points netxt char
+            if (c == '}')
+            {
+                // skip escaped '}'
+                if (i < len && format[i] == '}')
+                {
+                    i++;
+                    return ParserScanResult.EscapedChar;
+                }
+                else
+                {
+                    ExceptionUtil.ThrowFormatError();
+                    return ParserScanResult.NormalChar; // NOTE Don't reached
+                }
+            }
+            else if (c == '{')
+            {
+                // skip escaped '{'
+                if (i < len && format[i] == '{')
+                {
+                    i++;
+                    return ParserScanResult.EscapedChar;
+                }
+                else
+                {
+                    i--;
+                    return ParserScanResult.BraceOpen;
+                }
+            }
+            else
+            {
+                // ch is the normal char OR end of text
+                return ParserScanResult.NormalChar;
+            }
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ParserScanResult ScanFormatString(ReadOnlySpan<char> format, ref int i)
@@ -72,6 +113,141 @@ namespace Cysharp.Text
         // Accept only non-unicode numbers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsDigit(char c) => '0' <= c && c <= '9';
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ParseResult Parse(ReadOnlySpan<char> format, int i)
+        {
+            char c = default;
+            var len = format.Length;
+
+            i++; // Skip `{`
+
+            //  === Index Component ===
+            //   ('0'-'9')+ WS*
+
+            if (i == len || !IsDigit(c = format[i]))
+            {
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            int paramIndex = 0;
+            do
+            {
+                paramIndex = (paramIndex * 10) + c - '0';
+
+                if (++i == len)
+                    ExceptionUtil.ThrowFormatError();
+
+                c = format[i];
+            }
+            while (IsDigit(c) && paramIndex < ArgLengthLimit);
+
+            if (paramIndex >= ArgLengthLimit)
+            {
+                ExceptionUtil.ThrowFormatException();
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Alignment Component ===
+            //   comma WS* minus? ('0'-'9')+ WS*
+
+            int alignment = 0;
+
+            if (c == ',')
+            {
+                i++;
+
+                // skip whitespace.
+                while (i < len && (c = format[i]) == ' ')
+                    i++;
+
+                if (i == len)
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                var leftJustify = false;
+                if (c == '-')
+                {
+                    leftJustify = true;
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+
+                if (!IsDigit(c))
+                {
+                    ExceptionUtil.ThrowFormatError();
+                }
+
+                do
+                {
+                    alignment = (alignment * 10) + c - '0';
+
+                    if (++i == len)
+                        ExceptionUtil.ThrowFormatError();
+
+                    c = format[i];
+                }
+                while (IsDigit(c) && alignment < WidthLimit);
+
+                if (leftJustify)
+                    alignment *= -1;
+            }
+
+            // skip whitespace.
+            while (i < len && (c = format[i]) == ' ')
+                i++;
+
+            //  === Format String Component ===
+
+            ReadOnlySpan<char> itemFormatSpan = default;
+
+            if (c == ':')
+            {
+                i++;
+                int formatStart = i;
+
+                while (true)
+                {
+                    if (i == len)
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+                    c = format[i];
+
+                    if (c == '}')
+                    {
+                        break;
+                    }
+                    else if (c == '{')
+                    {
+                        ExceptionUtil.ThrowFormatError();
+                    }
+
+                    i++;
+                }
+
+                // has format
+                if (i > formatStart)
+                {
+                    itemFormatSpan = format.Slice(formatStart, i - formatStart);
+                }
+            }
+            else if (c != '}')
+            {
+                // Unexpected character
+                ExceptionUtil.ThrowFormatError();
+            }
+
+            i++; // Skip `}`
+            return new ParseResult(paramIndex, itemFormatSpan, i, alignment);
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static ParseResult Parse(string format, int i)
@@ -208,6 +384,7 @@ namespace Cysharp.Text
             return new ParseResult(paramIndex, itemFormatSpan, i, alignment);
         }
     }
+
     internal enum ParserScanResult
     {
         BraceOpen,

--- a/src/ZString/PreparedFormatHelper.cs
+++ b/src/ZString/PreparedFormatHelper.cs
@@ -20,13 +20,12 @@ namespace Cysharp.Text
             int len = format.Length;
 
             var copyFrom = 0;
-            var formatSpan = format.AsSpan();
 
             while (true)
             {
                 while (i < len)
                 {
-                    var parserScanResult = FormatParser.ScanFormatString(formatSpan, ref i);
+                    var parserScanResult = FormatParser.ScanFormatString(format, ref i);
 
                     if (ParserScanResult.NormalChar == parserScanResult && i < len)
                     {
@@ -84,13 +83,12 @@ namespace Cysharp.Text
             int len = format.Length;
 
             var copyFrom = 0;
-            var formatSpan = format.AsSpan();
 
             while (true)
             {
                 while (i < len)
                 {
-                    var parserScanResult = FormatParser.ScanFormatString(formatSpan, ref i);
+                    var parserScanResult = FormatParser.ScanFormatString(format, ref i);
 
                     if (ParserScanResult.NormalChar == parserScanResult && i < len)
                     {

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Cysharp.Text
 {
@@ -79,6 +79,75 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1>(ReadOnlySpan<char> format, T1 arg1)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2>(string format, T1 arg1, T2 arg2)
         {
             if (format == null)
@@ -152,6 +221,78 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2>(ReadOnlySpan<char> format, T1 arg1, T2 arg2)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -236,6 +377,81 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             if (format == null)
@@ -315,6 +531,84 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -405,6 +699,87 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             if (format == null)
@@ -490,6 +865,90 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -586,6 +1045,93 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             if (format == null)
@@ -677,6 +1223,96 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -779,6 +1415,99 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             if (format == null)
@@ -876,6 +1605,102 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -984,6 +1809,105 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             if (format == null)
@@ -1087,6 +2011,108 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -1201,6 +2227,111 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             if (format == null)
@@ -1310,6 +2441,114 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        case 13:
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }
@@ -1430,6 +2669,117 @@ namespace Cysharp.Text
             }
         }
         /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        case 13:
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
+                            continue;
+                        case 14:
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
         public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
             if (format == null)
@@ -1545,6 +2895,120 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+                        case 0:
+                            AppendFormatInternal(arg1, indexParse.Alignment, indexParse.FormatString, nameof(arg1));
+                            continue;
+                        case 1:
+                            AppendFormatInternal(arg2, indexParse.Alignment, indexParse.FormatString, nameof(arg2));
+                            continue;
+                        case 2:
+                            AppendFormatInternal(arg3, indexParse.Alignment, indexParse.FormatString, nameof(arg3));
+                            continue;
+                        case 3:
+                            AppendFormatInternal(arg4, indexParse.Alignment, indexParse.FormatString, nameof(arg4));
+                            continue;
+                        case 4:
+                            AppendFormatInternal(arg5, indexParse.Alignment, indexParse.FormatString, nameof(arg5));
+                            continue;
+                        case 5:
+                            AppendFormatInternal(arg6, indexParse.Alignment, indexParse.FormatString, nameof(arg6));
+                            continue;
+                        case 6:
+                            AppendFormatInternal(arg7, indexParse.Alignment, indexParse.FormatString, nameof(arg7));
+                            continue;
+                        case 7:
+                            AppendFormatInternal(arg8, indexParse.Alignment, indexParse.FormatString, nameof(arg8));
+                            continue;
+                        case 8:
+                            AppendFormatInternal(arg9, indexParse.Alignment, indexParse.FormatString, nameof(arg9));
+                            continue;
+                        case 9:
+                            AppendFormatInternal(arg10, indexParse.Alignment, indexParse.FormatString, nameof(arg10));
+                            continue;
+                        case 10:
+                            AppendFormatInternal(arg11, indexParse.Alignment, indexParse.FormatString, nameof(arg11));
+                            continue;
+                        case 11:
+                            AppendFormatInternal(arg12, indexParse.Alignment, indexParse.FormatString, nameof(arg12));
+                            continue;
+                        case 12:
+                            AppendFormatInternal(arg13, indexParse.Alignment, indexParse.FormatString, nameof(arg13));
+                            continue;
+                        case 13:
+                            AppendFormatInternal(arg14, indexParse.Alignment, indexParse.FormatString, nameof(arg14));
+                            continue;
+                        case 14:
+                            AppendFormatInternal(arg15, indexParse.Alignment, indexParse.FormatString, nameof(arg15));
+                            continue;
+                        case 15:
+                            AppendFormatInternal(arg16, indexParse.Alignment, indexParse.FormatString, nameof(arg16));
+                            continue;
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }

--- a/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
+++ b/src/ZString/Utf16/Utf16ValueStringBuilder.AppendFormat.tt
@@ -1,4 +1,4 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ import namespace="System.Linq" #>
 <#@ import namespace="System.Text" #>
@@ -85,6 +85,77 @@ namespace Cysharp.Text
                 if (copyLength > 0)
                 {
                     Append(format, copyFrom, copyLength);
+                }
+            }
+        }
+        /// <summary>Appends the string returned by processing a composite format string, each format item is replaced by the string representation of arguments.</summary>
+        public void AppendFormat<<#= CreateTypeArgument(i) #>>(ReadOnlySpan<char> format, <#= CreateParameters(i) #>)
+        {            
+            var copyFrom = 0;
+            for (int i = 0; i < format.Length; i++)
+            {
+                var c = format[i];
+                if (c == '{')
+                {
+                    // escape.
+                    if (i == format.Length - 1)
+                    {
+                        throw new FormatException("invalid format");
+                    }
+
+                    if (i != format.Length && format[i + 1] == '{')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '{'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                    }
+
+                    // try to find range
+                    var indexParse = FormatParser.Parse(format, i);
+                    copyFrom = indexParse.LastIndex;
+                    i = indexParse.LastIndex - 1;
+                    switch (indexParse.Index)
+                    {
+<# for(var j = 0; j < i; j++) { #>
+                        case <#= j #>:
+                            AppendFormatInternal(arg<#= j + 1 #>, indexParse.Alignment, indexParse.FormatString, nameof(arg<#= j + 1 #>));
+                            continue;
+<# } #>
+                        default:
+                            ThrowFormatException();
+                            break;
+                    }
+                }
+                else if (c == '}')
+                {
+                    if (i + 1 < format.Length && format[i + 1] == '}')
+                    {
+                        var size = i - copyFrom;
+                        Append(format.Slice(copyFrom, size));
+                        i = i + 1; // skip escaped '}'
+                        copyFrom = i;
+                        continue;
+                    }
+                    else
+                    {
+                        ThrowFormatException();
+                    }
+                }
+            }
+
+            {
+                // copy final string
+                var copyLength = format.Length - copyFrom;
+                if (copyLength > 0)
+                {
+                    Append(format.Slice(copyFrom, copyLength));
                 }
             }
         }

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.cs
@@ -28,7 +28,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -59,7 +59,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -77,7 +77,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -105,7 +105,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -139,7 +139,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -157,7 +157,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -185,7 +185,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -222,7 +222,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -240,7 +240,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -268,7 +268,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -308,7 +308,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -326,7 +326,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -354,7 +354,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -397,7 +397,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -415,7 +415,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -443,7 +443,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -489,7 +489,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -507,7 +507,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -535,7 +535,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -584,7 +584,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -602,7 +602,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -630,7 +630,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -682,7 +682,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -700,7 +700,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -728,7 +728,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -783,7 +783,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -801,7 +801,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -829,7 +829,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -887,7 +887,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -905,7 +905,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -933,7 +933,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -994,7 +994,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1012,7 +1012,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1040,7 +1040,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1104,7 +1104,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1122,7 +1122,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1150,7 +1150,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1217,7 +1217,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1235,7 +1235,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1263,7 +1263,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1333,7 +1333,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1351,7 +1351,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1379,7 +1379,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1452,7 +1452,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1470,7 +1470,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }
@@ -1498,7 +1498,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -1574,7 +1574,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -1592,7 +1592,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }

--- a/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
+++ b/src/ZString/Utf8/Utf8ValueStringBuilder.AppendFormat.tt
@@ -36,7 +36,7 @@ namespace Cysharp.Text
                     if (i != format.Length && format[i + 1] == '{')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '{'
                         copyFrom = i;
                         continue;
@@ -69,7 +69,7 @@ namespace Cysharp.Text
                     if (i + 1 < format.Length && format[i + 1] == '}')
                     {
                         var size = i - copyFrom;
-                        Append(format.AsSpan(copyFrom, size));
+                        Append(format, copyFrom, size);
                         i = i + 1; // skip escaped '}'
                         copyFrom = i;
                         continue;
@@ -87,7 +87,7 @@ namespace Cysharp.Text
                 var copyLength = format.Length - copyFrom;
                 if (copyLength > 0)
                 {
-                    Append(format.AsSpan(copyFrom, copyLength));
+                    Append(format, copyFrom, copyLength);
                 }
             }
         }

--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -222,6 +222,33 @@ namespace Cysharp.Text
         {
             Append(value);
             AppendLine();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string value, int startIndex, int count)
+        {
+            if (value == null)
+            {
+                if (startIndex == 0 && count == 0)
+                {
+                    return;
+                }
+                else
+                {
+                    throw new ArgumentNullException(nameof(value));
+                }
+            }
+
+#if UNITY_2018_3_OR_NEWER || NETSTANDARD2_0
+            var maxLen = UTF8NoBom.GetMaxByteCount(count);
+            if (buffer.Length - index < maxLen)
+            {
+                Grow(count);
+            }
+            index += UTF8NoBom.GetBytes(value, startIndex, count, buffer, index);
+#else
+            Append(value.AsSpan(startIndex, count));
+#endif
         }
 
         /// <summary>Appends the string representation of a specified value to this instance.</summary>

--- a/src/ZString/ZString.Format.cs
+++ b/src/ZString/ZString.Format.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System;
 
 namespace Cysharp.Text
 {
@@ -22,6 +23,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1>(ReadOnlySpan<char> format, T1 arg1)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2>(string format, T1 arg1, T2 arg2)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -36,6 +52,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2>(ReadOnlySpan<char> format, T1 arg1, T2 arg2)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3>(string format, T1 arg1, T2 arg2, T3 arg3)
@@ -54,6 +85,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -68,6 +114,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
@@ -86,6 +147,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -100,6 +176,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
@@ -118,6 +209,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -132,6 +238,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
@@ -150,6 +271,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -164,6 +300,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
@@ -182,6 +333,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -196,6 +362,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
@@ -214,6 +395,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -228,6 +424,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
@@ -246,6 +457,21 @@ namespace Cysharp.Text
 
         /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(string format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
         {
             var sb = new Utf16ValueStringBuilder(true);
@@ -260,5 +486,20 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16>(ReadOnlySpan<char> format, T1 arg1, T2 arg2, T3 arg3, T4 arg4, T5 arg5, T6 arg6, T7 arg7, T8 arg8, T9 arg9, T10 arg10, T11 arg11, T12 arg12, T13 arg13, T14 arg14, T15 arg15, T16 arg16)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
     }
 }

--- a/src/ZString/ZString.Format.tt
+++ b/src/ZString/ZString.Format.tt
@@ -6,6 +6,7 @@
 <#@ output extension=".cs" #>
 <#@ include file="T4Common.t4" once="true" #>
 using System.Runtime.CompilerServices;
+using System;
 
 namespace Cysharp.Text
 {
@@ -28,6 +29,21 @@ namespace Cysharp.Text
             }
         }
 
+        /// <summary>Replaces one or more format items in a string with the string representation of some specified objects.</summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Format<<#= CreateTypeArgument(i) #>>(ReadOnlySpan<char> format, <#= CreateParameters(i) #>)
+        {
+            var sb = new Utf16ValueStringBuilder(true);
+            try
+            {
+                sb.AppendFormat(format, <#= CreateParameterNames(i) #>);
+                return sb.ToString();
+            }
+            finally
+            {
+                sb.Dispose();
+            }
+        }
 <# } #>
     }
 }


### PR DESCRIPTION
This pull requests creates a ReadOnlySpan<char> based AppendFormat for Utf16 only, this is for resolving #62 

I attempted to implement a ReadOnlySpan<byte> based api for Utf8 but i found it too invasive to implement needing a lot of code duplication and rewriting of the core FormatParser specifically for utf-8 so that is not included. And without these deeper changes there would not be any performance improvement with including it so i've opted not to implement it, I will leave it up to someone else to try to implement it.

I've also not implemented a PreparedFormat api for this either, as the main purpose of this is to chain string builders together without creating a new string between them.