### PR TITLE
Added a test for joining HashSet values.

### DIFF
--- a/tests/ZString.Tests/JoinTest.cs
+++ b/tests/ZString.Tests/JoinTest.cs
@@ -61,6 +61,9 @@ namespace ZStringTests
             ZString.Join("_,_", (IReadOnlyCollection<int>)new[] { 1 }).Should().Be(string.Join("_,_", new[] { 1 }));
             ZString.Join("_,_", (IReadOnlyCollection<int>)new[] { 1, 2 }).Should().Be(string.Join("_,_", new[] { 1, 2 }));
             ZString.Join("_,_", (IReadOnlyCollection<int>)new[] { 1, 2, 3 }).Should().Be(string.Join("_,_", new[] { 1, 2, 3 }));
+
+            ZString.Join("_,_", new HashSet<int>()).Should().Be(string.Join("_,_", Array.Empty<string>()));
+            ZString.Join("_,_", new HashSet<int>{ 1 }).Should().Be(string.Join("_,_", new[] { 1 }));
         }
 
         [Fact]


### PR DESCRIPTION
Added a test for joining HashSet values.
It fails because the overload `Join<T>(string separator, params T[] values)` is used, even though there exists overloads for both `Join<T>(string separator, ICollection<T> values)` and `Join<T>(char separator, IEnumerable<T> values)`
I cannot explain this, haven't dived deeper into this.
The fix is easy, add another overload, but I am not sure how you want to handle this.
Is it a bug in the framework? Will it affect other types?
If it is just another overload, I can easily include the fix in the pull request.
In my code I just cast it to IEnumerable<> and it works.