### PR TITLE
.NET 7.0 Native AOT Compatible

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/EnumUtil.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/EnumUtil.cs
@@ -16,7 +16,12 @@ namespace Cysharp.Text
         static EnumUtil()
         {
             var enumNames = Enum.GetNames(typeof(T));
-            var values = Enum.GetValues(typeof(T));
+            var values =
+#if NET7_0_OR_GREATER
+                Enum.GetValuesAsUnderlyingType(typeof(T));
+#else
+                Enum.GetValues(typeof(T));
+#endif
             names = new Dictionary<T, string>(enumNames.Length);
             utf8names = new Dictionary<T, byte[]>(enumNames.Length);
             for (int i = 0; i < enumNames.Length; i++)

--- a/src/ZString/EnumUtil.cs
+++ b/src/ZString/EnumUtil.cs
@@ -16,7 +16,12 @@ namespace Cysharp.Text
         static EnumUtil()
         {
             var enumNames = Enum.GetNames(typeof(T));
-            var values = Enum.GetValues(typeof(T));
+            var values =
+#if NET7_0_OR_GREATER
+                Enum.GetValuesAsUnderlyingType(typeof(T));
+#else
+                Enum.GetValues(typeof(T));
+#endif
             names = new Dictionary<T, string>(enumNames.Length);
             utf8names = new Dictionary<T, byte[]>(enumNames.Length);
             for (int i = 0; i < enumNames.Length; i++)

--- a/src/ZString/ZString.csproj
+++ b/src/ZString/ZString.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net7.0;netstandard2.1;netstandard2.0</TargetFrameworks>
 		<RootNamespace>Cysharp.Text</RootNamespace>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
- Enum.GetValues() not compatible to .NET Native AOT.
- Enum.GetValuesAsUnderlyingType() compatible to .NET Native AOT but contains from .NET 7.0 or greater.
- So, Add net7.0 to TargetFrameworks.

#87 