### PR TITLE
Add define symbol for TextMeshPro

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ If you want to set a target version, ZString uses the `*.*.*` release tag so you
 
 Supporting minimum Unity version is 2021.3. The dependency managed DLL `System.Runtime.CompilerServices.Unsafe/6.0.0` is included with unitypackage. For git references, you will need to add them in another way as they are not included to avoid unnecessary dependencies; either extract the dll from unitypackage or download it from the [NuGet page](https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/6.0.0).
 
+TextMeshPro support is automatically enabled when importing the `com.unity.textmeshpro` package from package manager. (If you do not use the package manager, define the scripting define symbol `ZSTRING_TEXTMESHPRO_SUPPORT` to enable it.)
+
 Advanced Tips
 ---
 `ZString.CreateStringBuilder(notNested:true)` is a special optimized parameter that uses `ThreadStatic` buffer instead of rent from `ArrayPool`. It is slightly faster but can not use in nested.

--- a/src/ZString.Unity/Assets/Scripts/ZString/Unity/TextMeshProExtensions.SetStringBuilder.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Unity/TextMeshProExtensions.SetStringBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ZSTRING_TEXTMESHPRO_SUPPORT
+using System;
 using TMPro;
 
 namespace Cysharp.Text
@@ -12,3 +13,4 @@ namespace Cysharp.Text
         }
     }
 }
+#endif

--- a/src/ZString.Unity/Assets/Scripts/ZString/Unity/TextMeshProExtensions.cs
+++ b/src/ZString.Unity/Assets/Scripts/ZString/Unity/TextMeshProExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ZSTRING_TEXTMESHPRO_SUPPORT
+using System;
 using TMPro;
 
 namespace Cysharp.Text
@@ -193,3 +194,4 @@ namespace Cysharp.Text
 
     }
 }
+#endif

--- a/src/ZString.Unity/Assets/Scripts/ZString/ZString.asmdef
+++ b/src/ZString.Unity/Assets/Scripts/ZString/ZString.asmdef
@@ -10,5 +10,11 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [
+       {
+            "name": "com.unity.textmeshpro",
+            "expression": "",
+            "define": "ZSTRING_TEXTMESHPRO_SUPPORT"
+        }
+     ]
 }

--- a/src/ZString/Unity/TextMeshProExtensions.cs
+++ b/src/ZString/Unity/TextMeshProExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if ZSTRING_TEXTMESHPRO_SUPPORT
+using System;
 using TMPro;
 
 namespace Cysharp.Text
@@ -193,3 +194,4 @@ namespace Cysharp.Text
 
     }
 }
+#endif

--- a/src/ZString/Unity/TextMeshProExtensions.tt
+++ b/src/ZString/Unity/TextMeshProExtensions.tt
@@ -21,6 +21,7 @@
         return string.Join(", ", Enumerable.Range(0, i).Select(x => "arg" + x));
     }
 #>
+#if ZSTRING_TEXTMESHPRO_SUPPORT
 using System;
 using TMPro;
 
@@ -52,3 +53,4 @@ namespace Cysharp.Text
 <# } #>
     }
 }
+#endif


### PR DESCRIPTION
#69 

Use the version definition feature of asmdef to enable the extension only when the TextMeshPro package is imported.