### PR TITLE
Add a fast pass for ZString.Join when the argument is a string

### DIFF
--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -2,15 +2,18 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<SignAssembly>true</SignAssembly>
 		<AssemblyOriginatorKeyFile>../../opensource.snk</AssemblyOriginatorKeyFile>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
 		<PackageReference Include="System.Text.Json" Version="4.7.1" />
-		<ProjectReference Include="..\..\src\ZString\ZString.csproj" />
+		<ProjectReference Include="..\..\src\ZString\ZString.csproj">
+			<SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
+		</ProjectReference>
 	</ItemGroup>
 
 </Project>

--- a/sandbox/ConsoleApp/Program.cs
+++ b/sandbox/ConsoleApp/Program.cs
@@ -1,13 +1,8 @@
 ﻿using Cysharp.Text;
 using System;
-using System.Buffers;
-using System.Collections.Concurrent;
-using System.Linq;
 using System.Text;
-// using System.Text.Formatting;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Running;
 
 namespace ConsoleApp
 {
@@ -20,19 +15,34 @@ namespace ConsoleApp
     {
         static void Main(string[] args)
         {
+            // BenchmarkRunner.Run<JoinBenchmark>();
             Run();
         }
 
         static void Run()
         {
+            ZString.Join(",", "a", "b");
             TimeSpan span = new TimeSpan(12, 34, 56);
             Console.WriteLine($"string.Format: {string.Format(@"{0:h\,h\:mm\:ss}", span)}");
-
-
             Console.WriteLine($"ZString.Format: {ZString.Format(@"{0:h\,h\:mm\:ss}", span)}");
+        }
+    }
+    
+    public class JoinBenchmark
+    {
+        public string[] Source = new []{ "111", "222", "333"};
+        public const string Sp = ",";
 
+        [Benchmark]
+        public string StringJoin()
+        {
+            return string.Join(Sp, Source);
+        }
 
-
+        [Benchmark]
+        public string ZStringJoin() 
+        {
+            return ZString.Join(Sp, Source);
         }
     }
 

--- a/src/ZString/ZString.csproj
+++ b/src/ZString/ZString.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net7.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net7.0</TargetFrameworks>
 		<RootNamespace>Cysharp.Text</RootNamespace>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/tests/ZString.Tests/ZString.Tests.csproj
+++ b/tests/ZString.Tests/ZString.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net7.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <RootNamespace>ZStringTests</RootNamespace>
         <SignAssembly>true</SignAssembly>
@@ -23,7 +23,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\ZString\ZString.csproj" />
+        <ProjectReference Include="..\..\src\ZString\ZString.csproj">
+            <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
+        </ProjectReference>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Add fast pass when the argument of ZString.Join is a string, similar to string.Join.

## Benchmark result

```csharp    
    public class JoinBenchmark
    {
        string[] Source = new[] { "111", "222", "333" };

        [Benchmark]
        public string StringJoin()
        {
            return string.Join(",", Source);
        }

        [Benchmark]
        public string ZStringJoin() 
        {
            return ZString.Join(",", Source);
        }
    }
```

### Before

```
|      Method |     Mean |    Error |   StdDev |
|------------ |---------:|---------:|---------:|
|  StringJoin | 25.43 ns | 0.458 ns | 0.406 ns |
| ZStringJoin | 56.79 ns | 0.600 ns | 0.531 ns |
```

### After

```
|      Method |     Mean |    Error |   StdDev | Ratio |
|------------ |---------:|---------:|---------:|------:|
|  StringJoin | 26.37 ns | 0.203 ns | 0.190 ns |  1.00 |
| ZStringJoin | 28.57 ns | 0.195 ns | 0.182 ns |  1.08 |
```