### PR TITLE
Fix message of NestedStringBuilderCreationException throwed by Utf8ValueStringBuilder.ThrowNestedException()

### DIFF
--- a/src/ZString/Utf8ValueStringBuilder.cs
+++ b/src/ZString/Utf8ValueStringBuilder.cs
@@ -402,7 +402,7 @@ namespace Cysharp.Text
 
         static void ThrowNestedException()
         {
-            throw new NestedStringBuilderCreationException(nameof(Utf16ValueStringBuilder));
+            throw new NestedStringBuilderCreationException(nameof(Utf8ValueStringBuilder));
         }
 
         private void AppendFormatInternal<T>(T arg, int width, StandardFormat format, string argName)


### PR DESCRIPTION
Fix the typeName used in the message of NestedStringBuilderCreationException throwed by `Utf8ValueStringBuilder.ThrowNestedException()`.
I think it should be `nameof(Utf8ValueStringBuilder)`.