### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
+
     <!-- NuGet Package Information -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Company>Cysharp</Company>
     <Authors>Cysharp</Authors>
@@ -16,7 +20,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 </Project>

--- a/sandbox/BenchmarkVsReleasedVersion/BenchmarkVsReleasedVersion.csproj
+++ b/sandbox/BenchmarkVsReleasedVersion/BenchmarkVsReleasedVersion.csproj
@@ -1,23 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-      <TargetFramework>netcoreapp3.1</TargetFramework>
-      <!-- <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks> -->
-      <LangVersion>8.0</LangVersion>
-      <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+   <TargetFramework>netcoreapp3.1</TargetFramework>
+   <!-- <TargetFrameworks>netcoreapp3.1;netcoreapp2.1;net472</TargetFrameworks> -->
+   <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" Condition="$(TargetFramework) != 'netstandard3.1'" />
-      <PackageReference Include="ZString" Version="2.2.0" />
-      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    </ItemGroup>
+  <ItemGroup>
+   <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" Condition="$(TargetFramework) != 'netstandard3.1'" />
+   <PackageReference Include="ZString" Version="2.2.0" />
+   <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\ZString\ZString.csproj">
-          <Aliases>NewZString</Aliases>
-        </ProjectReference>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZString\ZString.csproj">
+     <Aliases>NewZString</Aliases>
+    </ProjectReference>
+  </ItemGroup>
 
 </Project>

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -1,19 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
-		<SignAssembly>true</SignAssembly>
-		<AssemblyOriginatorKeyFile>../../opensource.snk</AssemblyOriginatorKeyFile>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-		<PackageReference Include="System.Text.Json" Version="8.0.4" />
-		<ProjectReference Include="..\..\src\ZString\ZString.csproj">
-			<SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
-		</ProjectReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <ProjectReference Include="..\..\src\ZString\ZString.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
 
 </Project>

--- a/sandbox/PerfBenchmark/PerfBenchmark.csproj
+++ b/sandbox/PerfBenchmark/PerfBenchmark.csproj
@@ -1,19 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
-		<LangVersion>8.0</LangVersion>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-		<PackageReference Include="StringFormatter" Version="1.0.0.13" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="StringFormatter" Version="1.0.0.13" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\ZString\ZString.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZString\ZString.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/ZString/ZString.csproj
+++ b/src/ZString/ZString.csproj
@@ -1,205 +1,204 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net7.0</TargetFrameworks>
-		<RootNamespace>Cysharp.Text</RootNamespace>
-		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<LangVersion>9.0</LangVersion>
-		<Nullable>enable</Nullable>
-		<NoWarn>1701;1702;1591</NoWarn>
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <RootNamespace>Cysharp.Text</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <NoWarn>1701;1702;1591</NoWarn>
 
-		<!-- NuGet Packaging -->
-		<Description>Zero allocation StringBuilder for .NET Core and Unity.</Description>
-		<SignAssembly>true</SignAssembly>
-		<AssemblyOriginatorKeyFile>../../opensource.snk</AssemblyOriginatorKeyFile>
-	</PropertyGroup>
+    <!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
+    <Description>Zero allocation StringBuilder for .NET Core and Unity.</Description>
+  </PropertyGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
-		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-	</ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.1'">
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+  </ItemGroup>
 
-	<ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-		<PackageReference Include="System.Memory" Version="4.5.3" />
-	</ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Remove="Number\**\*.cs" Condition="$(TargetFramework) == 'net6.0' or $(TargetFramework) == 'net7.0'" />
-		<Compile Remove="Unity\**\**" />
-		<None Remove="Unity\**\**" />
-	</ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Number\**\*.cs" Condition="$(TargetFramework) == 'net6.0' or $(TargetFramework) == 'net7.0'" />
+    <Compile Remove="Unity\**\**" />
+    <None Remove="Unity\**\**" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Update="FormatHelper.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>FormatHelper.cs</LastGenOutput>
-		</None>
-		<None Update="PreparedFormat.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>PreparedFormat.cs</LastGenOutput>
-		</None>
-		<None Update="StringBuilder.AppendJoin.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>StringBuilder.AppendJoin.cs</LastGenOutput>
-		</None>
-		<None Update="Unity\TextMeshProExtensions.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>TextMeshProExtensions.cs</LastGenOutput>
-		</None>
-		<None Update="Utf16\Utf16ValueStringBuilder.AppendMany.tt">
-			<LastGenOutput>Utf16ValueStringBuilder.AppendMany.cs</LastGenOutput>
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-		<None Update="Utf16\Utf16ValueStringBuilder.CreateFormatter.tt">
-			<LastGenOutput>Utf16ValueStringBuilder.CreateFormatter.cs</LastGenOutput>
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-		<None Update="Utf16\Utf16ValueStringBuilder.SpanFormattableAppend.tt">
-			<LastGenOutput>Utf16ValueStringBuilder.SpanFormattableAppend.cs</LastGenOutput>
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-		<None Update="Utf8\Utf8ValueStringBuilder.AppendFormat.tt">
-			<LastGenOutput>Utf8ValueStringBuilder.AppendFormat.cs</LastGenOutput>
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-		<None Update="Utf8\Utf8ValueStringBuilder.AppendMany.tt">
-			<LastGenOutput>Utf8ValueStringBuilder.AppendMany.cs</LastGenOutput>
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-		<None Update="Utf8\Utf8ValueStringBuilder.CreateFormatter.tt">
-			<LastGenOutput>Utf8ValueStringBuilder.CreateFormatter.cs</LastGenOutput>
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-		<None Update="Utf8\Utf8ValueStringBuilder.SpanFormattableAppend.tt">
-			<LastGenOutput>Utf8ValueStringBuilder.SpanFormattableAppend.cs</LastGenOutput>
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-		<None Update="Utf16\Utf16ValueStringBuilder.AppendFormat.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>Utf16ValueStringBuilder.AppendFormat.cs</LastGenOutput>
-		</None>
-		<None Update="ZString.Concat.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>ZString.Concat.cs</LastGenOutput>
-		</None>
-		<None Update="ZString.Format.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>ZString.Format.cs</LastGenOutput>
-		</None>
-		<None Update="ZString.Prepare.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>ZString.Prepare.cs</LastGenOutput>
-		</None>
-		<None Update="ZString.Utf8Format.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-			<LastGenOutput>ZString.Utf8Format.cs</LastGenOutput>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Update="FormatHelper.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>FormatHelper.cs</LastGenOutput>
+    </None>
+    <None Update="PreparedFormat.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>PreparedFormat.cs</LastGenOutput>
+    </None>
+    <None Update="StringBuilder.AppendJoin.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>StringBuilder.AppendJoin.cs</LastGenOutput>
+    </None>
+    <None Update="Unity\TextMeshProExtensions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>TextMeshProExtensions.cs</LastGenOutput>
+    </None>
+    <None Update="Utf16\Utf16ValueStringBuilder.AppendMany.tt">
+      <LastGenOutput>Utf16ValueStringBuilder.AppendMany.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Utf16\Utf16ValueStringBuilder.CreateFormatter.tt">
+      <LastGenOutput>Utf16ValueStringBuilder.CreateFormatter.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Utf16\Utf16ValueStringBuilder.SpanFormattableAppend.tt">
+      <LastGenOutput>Utf16ValueStringBuilder.SpanFormattableAppend.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Utf8\Utf8ValueStringBuilder.AppendFormat.tt">
+      <LastGenOutput>Utf8ValueStringBuilder.AppendFormat.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Utf8\Utf8ValueStringBuilder.AppendMany.tt">
+      <LastGenOutput>Utf8ValueStringBuilder.AppendMany.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Utf8\Utf8ValueStringBuilder.CreateFormatter.tt">
+      <LastGenOutput>Utf8ValueStringBuilder.CreateFormatter.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Utf8\Utf8ValueStringBuilder.SpanFormattableAppend.tt">
+      <LastGenOutput>Utf8ValueStringBuilder.SpanFormattableAppend.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="Utf16\Utf16ValueStringBuilder.AppendFormat.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>Utf16ValueStringBuilder.AppendFormat.cs</LastGenOutput>
+    </None>
+    <None Update="ZString.Concat.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ZString.Concat.cs</LastGenOutput>
+    </None>
+    <None Update="ZString.Format.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ZString.Format.cs</LastGenOutput>
+    </None>
+    <None Update="ZString.Prepare.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ZString.Prepare.cs</LastGenOutput>
+    </None>
+    <None Update="ZString.Utf8Format.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ZString.Utf8Format.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Compile Update="FormatHelper.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>FormatHelper.tt</DependentUpon>
-		</Compile>
-		<Compile Update="PreparedFormat.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>PreparedFormat.tt</DependentUpon>
-		</Compile>
-		<Compile Update="StringBuilder.AppendJoin.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>StringBuilder.AppendJoin.tt</DependentUpon>
-		</Compile>
-		<Compile Update="Utf16\Utf16ValueStringBuilder.AppendFormat.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Utf16ValueStringBuilder.AppendFormat.tt</DependentUpon>
-		</Compile>
-		<Compile Update="Utf16\Utf16ValueStringBuilder.AppendMany.cs">
-			<DependentUpon>Utf16ValueStringBuilder.AppendMany.tt</DependentUpon>
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-		</Compile>
-		<Compile Update="Utf16\Utf16ValueStringBuilder.CreateFormatter.cs">
-			<DependentUpon>Utf16ValueStringBuilder.CreateFormatter.tt</DependentUpon>
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-		</Compile>
-		<Compile Update="Utf16\Utf16ValueStringBuilder.SpanFormattableAppend.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Utf16ValueStringBuilder.SpanFormattableAppend.tt</DependentUpon>
-		</Compile>
-		<Compile Update="Utf8\Utf8ValueStringBuilder.AppendFormat.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Utf8ValueStringBuilder.AppendFormat.tt</DependentUpon>
-		</Compile>
-		<Compile Update="Utf8\Utf8ValueStringBuilder.AppendMany.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Utf8ValueStringBuilder.AppendMany.tt</DependentUpon>
-		</Compile>
-		<Compile Update="Utf8\Utf8ValueStringBuilder.CreateFormatter.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Utf8ValueStringBuilder.CreateFormatter.tt</DependentUpon>
-		</Compile>
-		<Compile Update="Utf8\Utf8ValueStringBuilder.SpanFormattableAppend.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>Utf8ValueStringBuilder.SpanFormattableAppend.tt</DependentUpon>
-		</Compile>
-		<Compile Update="ZString.Concat.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ZString.Concat.tt</DependentUpon>
-		</Compile>
-		<Compile Update="ZString.Format.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ZString.Format.tt</DependentUpon>
-		</Compile>
-		<Compile Update="ZString.Prepare.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ZString.Prepare.tt</DependentUpon>
-		</Compile>
-		<Compile Update="ZString.Utf8Format.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ZString.Utf8Format.tt</DependentUpon>
-		</Compile>
+  <ItemGroup>
+    <Compile Update="FormatHelper.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>FormatHelper.tt</DependentUpon>
+    </Compile>
+    <Compile Update="PreparedFormat.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PreparedFormat.tt</DependentUpon>
+    </Compile>
+    <Compile Update="StringBuilder.AppendJoin.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>StringBuilder.AppendJoin.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Utf16\Utf16ValueStringBuilder.AppendFormat.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Utf16ValueStringBuilder.AppendFormat.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Utf16\Utf16ValueStringBuilder.AppendMany.cs">
+      <DependentUpon>Utf16ValueStringBuilder.AppendMany.tt</DependentUpon>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+    </Compile>
+    <Compile Update="Utf16\Utf16ValueStringBuilder.CreateFormatter.cs">
+      <DependentUpon>Utf16ValueStringBuilder.CreateFormatter.tt</DependentUpon>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+    </Compile>
+    <Compile Update="Utf16\Utf16ValueStringBuilder.SpanFormattableAppend.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Utf16ValueStringBuilder.SpanFormattableAppend.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Utf8\Utf8ValueStringBuilder.AppendFormat.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Utf8ValueStringBuilder.AppendFormat.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Utf8\Utf8ValueStringBuilder.AppendMany.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Utf8ValueStringBuilder.AppendMany.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Utf8\Utf8ValueStringBuilder.CreateFormatter.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Utf8ValueStringBuilder.CreateFormatter.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Utf8\Utf8ValueStringBuilder.SpanFormattableAppend.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Utf8ValueStringBuilder.SpanFormattableAppend.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ZString.Concat.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ZString.Concat.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ZString.Format.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ZString.Format.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ZString.Prepare.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ZString.Prepare.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ZString.Utf8Format.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ZString.Utf8Format.tt</DependentUpon>
+    </Compile>
 
-	</ItemGroup>
+  </ItemGroup>
 
-	<ItemGroup>
-		<None Include="PreparedFormat.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>PreparedFormat.tt</DependentUpon>
-		</None>
-		<None Include="ZString.Utf8Format.cs">
-			<DesignTime>True</DesignTime>
-			<AutoGen>True</AutoGen>
-			<DependentUpon>ZString.Utf8Format.tt</DependentUpon>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="PreparedFormat.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>PreparedFormat.tt</DependentUpon>
+    </None>
+    <None Include="ZString.Utf8Format.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ZString.Utf8Format.tt</DependentUpon>
+    </None>
+  </ItemGroup>
 
-	<ItemGroup>
-		<Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-	</ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
 
-	<!-- Copy files for Unity -->
-	<PropertyGroup>
-		<DestinationRoot>$(MSBuildProjectDirectory)\..\ZString.Unity\Assets\Scripts\ZString\</DestinationRoot>
-	</PropertyGroup>
-	<ItemGroup>
-		<TargetFiles1 Include="$(MSBuildProjectDirectory)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />
-	</ItemGroup>
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$(TargetFramework) == 'netstandard2.1'">
-		<Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
-	</Target>
+  <!-- Copy files for Unity -->
+  <PropertyGroup>
+    <DestinationRoot>$(MSBuildProjectDirectory)\..\ZString.Unity\Assets\Scripts\ZString\</DestinationRoot>
+  </PropertyGroup>
+  <ItemGroup>
+    <TargetFiles1 Include="$(MSBuildProjectDirectory)\**\*.cs" Exclude="**\bin\**\*.*;**\obj\**\*.*;_InternalVisibleTo.cs" />
+  </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="$(TargetFramework) == 'netstandard2.1'">
+    <Copy SourceFiles="@(TargetFiles1)" DestinationFiles="$(DestinationRoot)\%(RecursiveDir)%(Filename)%(Extension)" SkipUnchangedFiles="true" />
+  </Target>
 </Project>

--- a/tests/ZString.NetCore2Tests/ZString.NetCore2Tests.csproj
+++ b/tests/ZString.NetCore2Tests/ZString.NetCore2Tests.csproj
@@ -1,34 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp2.1</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <RootNamespace>ZStringTests</RootNamespace>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../../opensource.snk</AssemblyOriginatorKeyFile>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <RootNamespace>ZStringTests</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="1.2.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Compile Include="..\ZString.Tests\**\*.cs" Exclude="**\obj\**;**\bin\**" />
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\ZString.Tests\**\*.cs" Exclude="**\obj\**;**\bin\**" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\ZString\ZString.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+   <ProjectReference Include="..\..\src\ZString\ZString.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/ZString.Tests/ZString.Tests.csproj
+++ b/tests/ZString.Tests/ZString.Tests.csproj
@@ -1,31 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
-        <IsPackable>false</IsPackable>
-        <RootNamespace>ZStringTests</RootNamespace>
-        <SignAssembly>true</SignAssembly>
-        <AssemblyOriginatorKeyFile>../../opensource.snk</AssemblyOriginatorKeyFile>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <RootNamespace>ZStringTests</RootNamespace>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="5.10.2" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="1.2.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\ZString\ZString.csproj">
-            <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
-        </ProjectReference>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ZString\ZString.csproj">
+      <SetTargetFramework>TargetFramework=netstandard2.1</SetTargetFramework>
+    </ProjectReference>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
