### PR TITLE
ci: use OIDC for NuGet package push authentication

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -56,6 +56,10 @@ jobs:
         if: ${{ !inputs.dry-run }}
         env:
           NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      - run: dotnet nuget push "./publish/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   build-unity:
     needs: [update-packagejson]

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -27,6 +27,7 @@ jobs:
     needs: [update-packagejson]
     permissions:
       contents: read
+      id-token: write # required for NuGet Trusted Publish
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -27,7 +27,6 @@ jobs:
     needs: [update-packagejson]
     permissions:
       contents: read
-      id-token: write # required for NuGet Trusted Publish
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -46,20 +45,6 @@ jobs:
           name: nuget
           path: ./publish/
           retention-days: 1
-      # push nuget
-      - name: NuGet login (OIDC)
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
-        id: login
-        with:
-          user: ${{ secrets.NUGET_USER }}
-      - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
-        if: ${{ !inputs.dry-run }}
-        env:
-          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
-      - run: dotnet nuget push "./publish/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
-        if: ${{ !inputs.dry-run }}
-        env:
-          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   build-unity:
     needs: [update-packagejson]
@@ -111,8 +96,35 @@ jobs:
           path: ./src/ZString.Unity/ZString.Unity.${{ inputs.tag }}.unitypackage
           retention-days: 1
 
+  # publish
+  publish:
+    name: "Publish NuGet packages"
+    needs: [build-dotnet, build-unity]
+    permissions:
+      contents: read
+      id-token: write # required for NuGet Trusted Publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+      - uses: Cysharp/Actions/.github/actions/download-artifact@main
+      # push nuget
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "./nuget/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+      - run: dotnet nuget push "./nuget/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
+
   create-release:
-    needs: [update-packagejson, build-dotnet, build-unity]
+    needs: [update-packagejson, publish]
     permissions:
       contents: write
       id-token: write # required for NuGet Trusted Publish
@@ -128,7 +140,7 @@ jobs:
 
   cleanup:
     if: ${{ needs.update-packagejson.outputs.is-branch-created == 'true' }}
-    needs: [update-packagejson, build-dotnet, build-unity]
+    needs: [update-packagejson, create-release]
     permissions:
       contents: write
     uses: Cysharp/Actions/.github/workflows/clean-packagejson-branch.yaml@main

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -45,6 +45,16 @@ jobs:
           name: nuget
           path: ./publish/
           retention-days: 1
+      # push nuget
+      - name: NuGet login (OIDC)
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - run: dotnet nuget push "./publish/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k "${NUGET_KEY}"
+        if: ${{ !inputs.dry-run }}
+        env:
+          NUGET_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
 
   build-unity:
     needs: [update-packagejson]
@@ -106,7 +116,7 @@ jobs:
       commit-id: ${{ needs.update-packagejson.outputs.sha }}
       tag: ${{ inputs.tag }}
       dry-run: ${{ inputs.dry-run }}
-      nuget-push: true
+      nuget-push: false
       release-upload: true
       release-asset-path: ./ZString.Unity.${{ inputs.tag }}.unitypackage/ZString.Unity.${{ inputs.tag }}.unitypackage
     secrets: inherit

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -39,7 +39,7 @@ jobs:
       # pack nuget
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
       - run: dotnet test tests/ZString.Tests -c Release --no-build
-      - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
+      - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -p:IncludeSymbols=true -p:SymbolPackageFormat=snupkg -o ./publish
       # Store artifacts.
       - uses: Cysharp/Actions/.github/actions/upload-artifact@main
         with:


### PR DESCRIPTION
This updates the build-release workflow to leverage OpenID Connect (OIDC) for authenticating with NuGet.org. The package push operation is now performed directly within the build job, replacing static API key usage with ephemeral credentials for enhanced security.
