### PR TITLE
Remove redundant Unity sample configs from package.json

### DIFF
--- a/src/ZString.Unity/Assets/Scripts/ZString/package.json
+++ b/src/ZString.Unity/Assets/Scripts/ZString/package.json
@@ -10,12 +10,5 @@
 	],
 	"license": "MIT",
 	"category": "Scripting",
-	"dependencies": {},
-	"samples": [
-		{
-			"displayName": "Required Managed DLLs",
-			"description": "Import Required Managed DLLs",
-			"path": "Samples~/RequiredManagedDLLs"
-		}
-	]
+	"dependencies": {}
 }


### PR DESCRIPTION
Aims to fix the following bug: https://github.com/Cysharp/ZString/issues/143